### PR TITLE
feat: remove exposed backend port, route all traffic through nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Node modules - built inside container for the correct platform
+node_modules/
+backend/node_modules/
+frontend/node_modules/
+
+# Git
+.git/
+.gitignore
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Legacy app
+legacy/
+
+# Environment files
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ coverage/
 
 # Docker
 docker-compose.override.yml
-.dockerignore
 
 # Python
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     profiles: ["prod"]
     image: ghcr.io/balladebaderne/cookbook-backend:latest
     restart: unless-stopped
-    ports:
-      - "3000:3000"
     environment:
       - NODE_ENV=production
       - PORT=3000
@@ -37,8 +35,6 @@ services:
     build:
       context: .
       dockerfile: ./backend/Dockerfile
-    ports:
-      - "3000:3000"
     environment:
       - NODE_ENV=development
       - PORT=3000

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+# Node modules - built inside container for the correct platform
+node_modules/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Environment files
+.env*

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,7 +17,7 @@ server {
     }
 
     # Proxy Swagger UI
-    location /api-docs {
+    location /apidocs {
         proxy_pass http://backend:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

- Backend port 3000 er ikke længere eksponeret til host — al ekstern trafik går igennem nginx på port 80
- `.dockerignore` tilføjet (root + frontend) — forhindrer Mac-binaries i at ende i Linux-images på VM
- Nginx routing fungerer korrekt internt via `cookbook-network`

### Arkitektur

```
Ekstern trafik
     │
     ▼
 nginx :80
     │
     ├── /        → React SPA (statiske filer)
     ├── /api     → http://backend:3000 (intern netværk)
     └── /apidocs → http://backend:3000 (intern netværk)
                         ↑
                  Ikke tilgængelig direkte udefra
```

### Commits

- `3db7d38` feat: remove exposed backend port, route all traffic through nginx
- `b456645` Merge feature/nginx-no-exposed-backend-port into dev
- `1516559` fix: add .dockerignore to prevent Mac binaries in Linux containers

## Test plan

- [ ] `docker compose up -d` starter alle containers uden fejl
- [ ] Frontend tilgængelig på `http://localhost`
- [ ] API tilgængeligt via `http://localhost/api`
- [ ] Backend port 3000 er **ikke** tilgængelig direkte fra host
- [ ] CI pipeline kører security audit + bygger images

🤖 Generated with [Claude Code](https://claude.com/claude-code)