### PR TITLE
Two-VM Azure deploy pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -70,11 +71,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase image prefix
+        id: prefix
+        run: echo "value=$(echo '${{ env.IMAGE_PREFIX }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (tags & labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}/cookbook-${{ matrix.service }}
+          images: ${{ steps.prefix.outputs.value }}/cookbook-${{ matrix.service }}
           tags: |
             type=ref,event=branch
             type=sha,prefix=sha-
@@ -89,8 +94,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  deploy:
-    name: Deploy to Azure VM
+  deploy-backend:
+    name: Deploy backend to Azure VM
     runs-on: ubuntu-latest
     needs: build-and-push
     if: github.ref == 'refs/heads/master'
@@ -104,28 +109,55 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.SSH_HOST_BACKEND }} >> ~/.ssh/known_hosts
 
-      - name: Test SSH connection
+      - name: Copy backend compose file
         run: |
-          ssh -i ~/.ssh/id_rsa \
-          ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-          "echo 'SSH connection successful'"
+          scp -i ~/.ssh/id_rsa docker-compose.backend.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_BACKEND }}:~/app/docker-compose.yml
 
-      - name: Copy docker-compose to VM
-        run: |
-          rsync -avz \
-            -e "ssh -i ~/.ssh/id_rsa" \
-            ./docker-compose.yml \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.DEPLOY_PATH }}
-
-      - name: Deploy with Docker Compose
+      - name: Pull and start backend container
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER_LC: ${{ github.repository_owner }}
         run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
           ssh -i ~/.ssh/id_rsa \
-          ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-          "cd ${{ secrets.DEPLOY_PATH }} && \
-           echo $TOKEN | docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
-           docker compose --profile prod pull && \
-           docker compose --profile prod up -d"
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_BACKEND }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"
+
+  deploy-nginx:
+    name: Deploy nginx to Azure VM
+    runs-on: ubuntu-latest
+    needs: [build-and-push, deploy-backend]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
+
+      - name: Copy nginx compose file
+        run: |
+          scp -i ~/.ssh/id_rsa docker-compose.nginx.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}:~/app/docker-compose.yml
+
+      - name: Pull and start nginx container
+        env:
+          OWNER_LC: ${{ github.repository_owner }}
+        run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose up -d"

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,0 +1,23 @@
+services:
+  backend:
+    image: ghcr.io/${GITHUB_OWNER}/cookbook-backend:latest
+    container_name: cookbook-backend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DB_PATH=/app/data/app.db
+    volumes:
+      - cookbook_data:/app/data
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  cookbook_data:
+    driver: local

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,0 +1,9 @@
+services:
+  frontend:
+    image: ghcr.io/${GITHUB_OWNER}/cookbook-frontend:latest
+    container_name: cookbook-frontend
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    environment:
+      - BACKEND_HOST=${BACKEND_PRIVATE_IP}:3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+ENV BACKEND_HOST=backend:3000
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -4,21 +4,18 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Send alle routes til index.html (SPA)
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy /api-kald videre til backend
     location /api {
-        proxy_pass http://backend:3000;
+        proxy_pass http://${BACKEND_HOST};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
 
-    # Proxy Swagger UI
     location /apidocs {
-        proxy_pass http://backend:3000;
+        proxy_pass http://${BACKEND_HOST};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/infrastructure/azure-setup.sh
+++ b/infrastructure/azure-setup.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provisions the two-VM cookbook deployment in Azure and wires up
+# GitHub repo secrets so the CI/CD pipeline can SSH into the VMs.
+#
+# Run interactively the first time:   bash infrastructure/azure-setup.sh
+# Safe to re-run: resource creation is idempotent; existing resources are reused.
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
+LOCATION="${LOCATION:-francecentral}"
+VNET_NAME="${VNET_NAME:-cookbook-vnet}"
+SUBNET_NAME="${SUBNET_NAME:-cookbook-subnet}"
+VNET_CIDR="10.0.0.0/16"
+SUBNET_CIDR="10.0.1.0/24"
+
+NGINX_VM="${NGINX_VM:-cookbook-nginx}"
+BACKEND_VM="${BACKEND_VM:-cookbook-backend}"
+VM_SIZE="${VM_SIZE:-Standard_B1s}"
+VM_IMAGE="Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
+ADMIN_USER="${ADMIN_USER:-azureuser}"
+SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-$HOME/.ssh/id_rsa.pub}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/id_rsa}"
+
+GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
+
+BACKEND_PORT=3000
+
+log() { printf '\n\033[1;34m[setup]\033[0m %s\n' "$*"; }
+die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v az >/dev/null || die "Azure CLI (az) not installed."
+command -v gh >/dev/null || die "GitHub CLI (gh) not installed."
+command -v ssh >/dev/null || die "ssh not installed."
+[[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
+[[ -f "$SSH_KEY_PATH" ]] || die "SSH private key not found at $SSH_KEY_PATH"
+
+log "Verifying Azure login..."
+az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+ACCOUNT_NAME=$(az account show --query name -o tsv)
+log "Azure account: $ACCOUNT_NAME"
+
+log "Verifying GitHub login..."
+gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+
+# ---------- Resource group ----------
+log "Creating resource group '$RESOURCE_GROUP' in $LOCATION..."
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION" --output none
+
+# ---------- Network ----------
+log "Creating VNet '$VNET_NAME' ($VNET_CIDR) and subnet '$SUBNET_NAME' ($SUBNET_CIDR)..."
+az network vnet create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VNET_NAME" \
+  --address-prefixes "$VNET_CIDR" \
+  --subnet-name "$SUBNET_NAME" \
+  --subnet-prefixes "$SUBNET_CIDR" \
+  --output none
+
+create_vm() {
+  local name="$1"
+  log "Creating VM '$name'..."
+  if az vm show -g "$RESOURCE_GROUP" -n "$name" >/dev/null 2>&1; then
+    log "VM '$name' already exists, skipping create."
+    return
+  fi
+  az vm create \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$name" \
+    --image "$VM_IMAGE" \
+    --size "$VM_SIZE" \
+    --admin-username "$ADMIN_USER" \
+    --ssh-key-values "$SSH_PUB_KEY_PATH" \
+    --vnet-name "$VNET_NAME" \
+    --subnet "$SUBNET_NAME" \
+    --public-ip-sku Standard \
+    --output none
+}
+
+create_vm "$NGINX_VM"
+create_vm "$BACKEND_VM"
+
+# ---------- NSG rules ----------
+log "Opening ports 80 and 443 on '$NGINX_VM'..."
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$NGINX_VM" --port 80  --priority 1001 --output none || true
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$NGINX_VM" --port 443 --priority 1002 --output none || true
+
+log "Allowing backend port $BACKEND_PORT from VNet ($VNET_CIDR) only on '$BACKEND_VM'..."
+BACKEND_NSG=$(az vm show -g "$RESOURCE_GROUP" -n "$BACKEND_VM" \
+  --query "networkProfile.networkInterfaces[0].id" -o tsv \
+  | xargs -I{} az network nic show --ids {} --query "networkSecurityGroup.id" -o tsv)
+
+if [[ -z "$BACKEND_NSG" ]]; then
+  # Fallback: NSG named after the VM (default az vm create behaviour)
+  BACKEND_NSG=$(az network nsg show -g "$RESOURCE_GROUP" -n "${BACKEND_VM}NSG" --query id -o tsv 2>/dev/null || true)
+fi
+[[ -n "$BACKEND_NSG" ]] || die "Could not locate NSG for $BACKEND_VM"
+
+az network nsg rule create \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$(basename "$BACKEND_NSG")" \
+  --name "allow-backend-from-vnet" \
+  --priority 1100 \
+  --source-address-prefixes "$VNET_CIDR" \
+  --destination-port-ranges "$BACKEND_PORT" \
+  --access Allow --protocol Tcp --direction Inbound \
+  --output none 2>/dev/null || log "Rule 'allow-backend-from-vnet' already exists."
+
+# ---------- IP lookup ----------
+log "Fetching IP addresses..."
+NGINX_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$NGINX_VM"   --query publicIps  -o tsv)
+BACKEND_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$BACKEND_VM" --query publicIps  -o tsv)
+BACKEND_PRIVATE_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$BACKEND_VM" --query privateIps -o tsv)
+
+log "  nginx   public IP:  $NGINX_IP"
+log "  backend public IP:  $BACKEND_IP"
+log "  backend private IP: $BACKEND_PRIVATE_IP"
+
+# ---------- Provision VMs over SSH ----------
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i "$SSH_KEY_PATH")
+
+wait_for_ssh() {
+  local host="$1"
+  log "Waiting for SSH on $host..."
+  for _ in $(seq 1 30); do
+    if ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$host" 'true' 2>/dev/null; then
+      return 0
+    fi
+    sleep 5
+  done
+  die "SSH never came up on $host"
+}
+
+provision() {
+  local host="$1" label="$2"
+  wait_for_ssh "$host"
+  log "Provisioning $label ($host): base packages + Docker..."
+  ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$host" 'bash -s' <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+sudo -E apt-get update -y
+sudo -E apt-get upgrade -y
+sudo -E apt-get install -y curl wget git unzip ca-certificates gnupg lsb-release
+
+if ! command -v docker >/dev/null 2>&1; then
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo -E apt-get update -y
+  sudo -E apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo usermod -aG docker "$USER"
+fi
+sudo systemctl enable --now docker
+mkdir -p "$HOME/app"
+REMOTE
+}
+
+provision "$NGINX_IP"   "nginx VM"
+provision "$BACKEND_IP" "backend VM"
+
+# ---------- GitHub secrets ----------
+log "Setting GitHub secrets on $GITHUB_REPO..."
+set_secret() {
+  printf '%s' "$2" | gh secret set "$1" -R "$GITHUB_REPO" --body -
+}
+
+set_secret SSH_USER            "$ADMIN_USER"
+set_secret SSH_HOST_NGINX      "$NGINX_IP"
+set_secret SSH_HOST_BACKEND    "$BACKEND_IP"
+set_secret BACKEND_PRIVATE_IP  "$BACKEND_PRIVATE_IP"
+gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
+
+log "Done."
+cat <<SUMMARY
+
+Two-VM deployment provisioned:
+  Resource group:     $RESOURCE_GROUP
+  nginx VM:           $NGINX_IP   (ports 80/443 open)
+  backend VM:         $BACKEND_IP (port $BACKEND_PORT open from VNet only)
+  backend private IP: $BACKEND_PRIVATE_IP
+
+GitHub secrets set on $GITHUB_REPO:
+  SSH_USER, SSH_HOST_NGINX, SSH_HOST_BACKEND,
+  BACKEND_PRIVATE_IP, SSH_PRIVATE_KEY
+
+Push to master to trigger the deploy pipeline.
+SUMMARY

--- a/infrastructure/azure-teardown.sh
+++ b/infrastructure/azure-teardown.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deletes the entire resource group used by the cookbook deployment.
+# This is destructive and irreversible — requires explicit confirmation.
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
+
+log() { printf '\n\033[1;34m[teardown]\033[0m %s\n' "$*"; }
+die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v az >/dev/null || die "Azure CLI (az) not installed."
+az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+
+if ! az group show --name "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  log "Resource group '$RESOURCE_GROUP' does not exist. Nothing to do."
+  exit 0
+fi
+
+log "About to DELETE resource group '$RESOURCE_GROUP' and everything in it:"
+az resource list -g "$RESOURCE_GROUP" --query "[].{name:name,type:type}" -o table || true
+
+read -rp $'\nType the resource group name to confirm: ' confirm
+[[ "$confirm" == "$RESOURCE_GROUP" ]] || die "Confirmation did not match. Aborting."
+
+log "Deleting..."
+az group delete --name "$RESOURCE_GROUP" --yes --no-wait
+log "Delete submitted. Azure will finish in the background."


### PR DESCRIPTION
## Summary
- Splits deploy across a public nginx VM and a VNet-internal backend VM so port 3000 is never exposed to the internet
- Adds `infrastructure/azure-setup.sh` + `azure-teardown.sh` to provision/tear down `rg-balladebaderne` (two Ubuntu 22.04 VMs, NSG locks backend to VNet)
- Reworks `ci-cd.yml` with `deploy-backend` → `deploy-nginx` jobs (master only)
- Frontend image now serves both the SPA and the reverse proxy via an envsubst `nginx.conf.template`, so the same image runs in dev and on the nginx VM

## Test plan
- [x] build-and-push succeeded on dev
- [x] azure-setup.sh ran clean end-to-end, secrets set on repo
- [ ] Merge triggers deploy-backend + deploy-nginx successfully
- [ ] http://40.89.143.137 serves the cookbook UI and /api reaches the backend over the VNet