### PR TITLE
fix: deploy job package permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -100,6 +100,10 @@ jobs:
     needs: build-and-push
     if: github.ref == 'refs/heads/master'
 
+    permissions:
+      contents: read
+      packages: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -133,6 +137,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-push, deploy-backend]
     if: github.ref == 'refs/heads/master'
+
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout repository

--- a/infrastructure/azure-setup.sh
+++ b/infrastructure/azure-setup.sh
@@ -163,7 +163,9 @@ provision "$BACKEND_IP" "backend VM"
 # ---------- GitHub secrets ----------
 log "Setting GitHub secrets on $GITHUB_REPO..."
 set_secret() {
-  printf '%s' "$2" | gh secret set "$1" -R "$GITHUB_REPO" --body -
+  # NB: `--body -` would literally store the string "-"; omit --body so gh
+  # reads the value from stdin instead.
+  printf '%s' "$2" | gh secret set "$1" -R "$GITHUB_REPO"
 }
 
 set_secret SSH_USER            "$ADMIN_USER"


### PR DESCRIPTION
## Summary
- Grants `packages: read` on `deploy-backend` and `deploy-nginx` so the runner's `GITHUB_TOKEN` can pull from ghcr.io
- Fixes `azure-setup.sh` writing the literal string "-" into GitHub secrets (dropped the `--body -` flag that gh doesn't interpret as stdin)

## Test plan
- [ ] Merge triggers deploy-backend + deploy-nginx successfully
- [ ] http://40.89.143.137 serves the cookbook UI via the VNet-private backend