### PR TITLE
ci: allow manual deploy trigger + final two-VM deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,7 +98,7 @@ jobs:
     name: Deploy backend to Azure VM
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
 
     permissions:
       contents: read
@@ -136,7 +136,7 @@ jobs:
     name: Deploy nginx to Azure VM
     runs-on: ubuntu-latest
     needs: [build-and-push, deploy-backend]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` condition to deploy jobs so future deploys can be triggered from any branch without a PR
- Verified green end-to-end on dev: build+push → deploy-backend → deploy-nginx, and http://40.89.143.137 serves the cookbook UI with backend reachable via VNet-private IP

## Test plan
- [x] Full pipeline green on dev (run 24401707595)
- [x] `curl http://40.89.143.137/` returns 200 (frontend served)
- [x] `curl http://40.89.143.137/apidocs/` returns 200 (backend reachable via nginx reverse proxy over VNet)
- [ ] Same pipeline runs green on master merge