### PR TITLE
feat: single-VM provisioning + mode-aware deploy pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,11 +94,53 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  deploy-single-vm:
+    name: Deploy to single VM
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: |
+      vars.DEPLOY_MODE == 'single' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Copy compose file
+        run: |
+          scp -i ~/.ssh/id_rsa docker-compose.single-vm.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose.yml
+
+      - name: Pull and start containers
+        env:
+          OWNER_LC: ${{ github.repository_owner }}
+        run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"
+
   deploy-backend:
     name: Deploy backend to Azure VM
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    if: |
+      vars.DEPLOY_MODE == 'two-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
 
     permissions:
       contents: read
@@ -136,7 +178,9 @@ jobs:
     name: Deploy nginx to Azure VM
     runs-on: ubuntu-latest
     needs: [build-and-push, deploy-backend]
-    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    if: |
+      vars.DEPLOY_MODE == 'two-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
 
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -1,220 +1,77 @@
-# Cookbook - Recipe Management Application
+# Cookbook — Recipe Management Application
 
-A full-stack recipe management web application where users can browse, view, and manage recipes.
-
-The application is deployed on an Azure Virtual Machine using Docker and is accessible online.
-
----
-
-## Live Deployments
-
-**Frontend:**  
-http://172.189.59.40
-
-**Backend API:**  
-http://172.189.59.40/api
-
-**API Documentation (Swagger):**  
-http://172.189.59.40/apidocs/
-
----
+A full-stack recipe management web application where users can browse,
+view, and manage recipes. Deployed on Azure VMs via Docker and GitHub
+Actions.
 
 ## Tech Stack
 
-### Backend
-- Node.js
-- Express.js
-- SQLite3
-- OpenAPI 3.0 (Swagger)
-
-### Frontend
-- React
-- Nginx (served via Docker)
-
-### Infrastructure
-- Azure Virtual Machine (Ubuntu)
-- Docker
-- Docker Compose
-- GitHub Actions
-- GitHub Container Registry (GHCR)
-
-### DevOps & Version Control
-- Git
-- GitHub
-
----
+**Backend:** Node.js, Express, SQLite3, OpenAPI 3.0 (Swagger)
+**Frontend:** React (Vite), served by Nginx
+**Infrastructure:** Azure VMs (Ubuntu 22.04), Docker, Docker Compose,
+GitHub Actions, GitHub Container Registry
 
 ## Project Structure
 
 ```text
 cookbook/
-|-- backend/                  # Express backend API
-|   |-- index.js
-|   |-- package.json
-|   `-- Dockerfile
-|-- frontend/                 # React frontend
-|   |-- src/
-|   |-- package.json
-|   |-- nginx.conf
-|   `-- Dockerfile
-|-- docker-compose.yml        # Local development with image builds
-|-- docker-compose.prod.yml   # Production deployment with GHCR images
-|-- openapi.yaml              # OpenAPI specification
-`-- README.md
+├── backend/                      # Express API + Dockerfile
+├── frontend/                     # React + nginx Dockerfile
+├── infrastructure/               # Azure provisioning scripts
+│   ├── create_vm.sh              # single-VM setup
+│   ├── create_two_vms.sh         # two-VM (nginx + backend) setup
+│   ├── azure-teardown.sh         # deletes the resource group
+│   └── README.md
+├── docker-compose.yml            # local dev
+├── docker-compose.single-vm.yml  # prod: single VM
+├── docker-compose.nginx.yml      # prod: two-VM, nginx host
+├── docker-compose.backend.yml    # prod: two-VM, backend host
+├── openapi.yaml
+└── .github/workflows/ci-cd.yml
 ```
 
----
-
-## Running Locally with Docker
-
-### Requirements
-
-- Docker
-- Docker Compose
-
-### Start application
+## Running Locally
 
 ```bash
-docker compose up -d --build
+docker compose --profile dev up -d --build   # start
+docker compose --profile dev down            # stop
 ```
 
-### Stop application
+- Frontend: http://localhost
+- Backend API: http://localhost:3000/api
+- Swagger: http://localhost:3000/apidocs
+
+## Deploying to Azure
+
+All Azure provisioning lives under [`infrastructure/`](./infrastructure/README.md).
+Two topologies are supported — pick one:
+
+- **Single VM** — `bash infrastructure/create_vm.sh`
+- **Two VMs** (public nginx + internal backend) — `bash infrastructure/create_two_vms.sh`
+
+The create scripts set the repo variable `DEPLOY_MODE` so the CI/CD
+pipeline knows which deploy job to run. Push to `master` (or trigger
+`workflow_dispatch`) to deploy. Tear down with:
 
 ```bash
-docker compose down
+bash infrastructure/azure-teardown.sh
 ```
 
-### Access locally
+See [`infrastructure/README.md`](./infrastructure/README.md) for
+prerequisites, secrets, and the full cycle.
 
-Frontend:  
-http://localhost
+## Pipeline Overview
 
-Backend API:  
-http://localhost:3000/api
+[`ci-cd.yml`](./.github/workflows/ci-cd.yml) runs on push to
+`master`/`dev` and on `workflow_dispatch`:
 
-Swagger docs:  
-http://localhost:3000/apidocs
-
----
-
-## Current Pipeline Overview
-
-The repository currently deploys from GitHub Actions. The workflow is defined in [`.github/workflows/ci-cd.yml`](./.github/workflows/ci-cd.yml).
-
-### How it works now
-
-1. A push to `master` or `dev` starts the pipeline.
-2. The `build` job installs dependencies and runs lint, tests, and build steps for both `backend` and `frontend`.
-3. On `master`, the workflow publishes Docker images to GitHub Container Registry:
-   - `ghcr.io/<owner>/cookbook-backend:latest`
-   - `ghcr.io/<owner>/cookbook-frontend:latest`
-4. The deploy job then SSHs into the VM using GitHub Secrets.
-5. The VM logs into `ghcr.io`, pulls the latest images, and starts them with `docker compose -f docker-compose.prod.yml up -d`.
-
-### Which secrets are involved
-
-The pipeline still depends on GitHub Secrets for access:
-
-- `SSH_PRIVATE_KEY`: private key used by GitHub Actions to SSH into the VM
-- `SSH_HOST`: public IP or DNS name of the VM
-- `SSH_USER`: SSH username on the VM, likely `azureuser`
-- `DEPLOY_PATH`: directory on the VM where the production compose file lives
-- `GHCR_USERNAME`: GitHub username or machine user with package read access
-- `GHCR_PAT`: GitHub token with permission to read packages from GHCR
-
-### Important difference
-
-The VM no longer needs the full repository copied onto it for deployment. It only needs:
-
-- Docker and Docker Compose installed
-- access to `ghcr.io`
-- the production compose file
-- a GitHub token that can pull the package images
-
----
-
-## Azure VM Access
-
-### What we know from this repository
-
-The repository documents:
-
-- SSH user: `azureuser`
-- public IP: `172.189.59.40`
-
-That means the expected login command is:
-
-```bash
-ssh azureuser@172.189.59.40
-```
-
-### What is not stored in this repository
-discovered people in the project and commited a change
-
-### Update application from GitHub
-
-This repo does **not** contain Azure infrastructure files such as Terraform, Bicep, or ARM templates, so it does not tell us:
-
-- the Azure resource group
-- the VM name in Azure
-- the Azure subscription
-- whether a DNS name is configured
-
-You would need to check one of these places for that:
-
-- the Azure Portal
-- repository or organization secrets in GitHub
-- whoever created the VM
-
-### If SSH fails
-
-Common reasons:
-
-- your local machine does not have the correct private key
-- port `22` is blocked in the VM network security group
-- `azureuser` is not the right user anymore
-- the VM public IP has changed
-
----
-
-## VM Deployment Layout
-
-The production deployment now expects a directory like this on the VM:
-
-```text
-<DEPLOY_PATH>/
-|-- .env
-`-- docker-compose.prod.yml
-```
-
-The `.env` file is written by the workflow and includes:
-
-```env
-GITHUB_REPOSITORY_OWNER=<owner>
-IMAGE_TAG=latest
-```
-
----
-
-## Manual Commands On The VM
-
-If you SSH into the VM and want to update the running app manually:
-
-```bash
-cd <DEPLOY_PATH>
-echo "<GHCR_PAT>" | docker login ghcr.io -u "<GHCR_USERNAME>" --password-stdin
-docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml up -d
-```
-
-To inspect what is running:
-
-```bash
-docker compose -f docker-compose.prod.yml ps
-docker images | grep cookbook
-```
-
----
+1. **security-audit** — `npm audit` on backend + frontend.
+2. **build-and-push** — builds backend + frontend images, pushes to
+   `ghcr.io/balladebaderne/cookbook-{backend,frontend}`.
+3. **deploy** — only on `master` or manual dispatch. Picks one path
+   based on the `DEPLOY_MODE` repo variable:
+   - `single` → SSHs to `SSH_HOST`, runs `docker-compose.single-vm.yml`
+   - `two-vms` → SSHs to backend + nginx VMs with their respective compose files
 
 ## Repository
 

--- a/docker-compose.single-vm.yml
+++ b/docker-compose.single-vm.yml
@@ -1,0 +1,40 @@
+services:
+  backend:
+    image: ghcr.io/${GITHUB_OWNER}/cookbook-backend:latest
+    container_name: cookbook-backend
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DB_PATH=/app/data/app.db
+    volumes:
+      - cookbook_data:/app/data
+    networks:
+      - cookbook-network
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  frontend:
+    image: ghcr.io/${GITHUB_OWNER}/cookbook-frontend:latest
+    container_name: cookbook-frontend
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    environment:
+      - BACKEND_HOST=backend:3000
+    depends_on:
+      - backend
+    networks:
+      - cookbook-network
+
+volumes:
+  cookbook_data:
+    driver: local
+
+networks:
+  cookbook-network:
+    driver: bridge

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,121 @@
+# Infrastructure
+
+Scripts that provision (and tear down) the Azure VMs used to run the
+cookbook app. Every group member should be able to run through a full
+cycle independently:
+
+```
+create_vm.sh  → push to master  → app live  → azure-teardown.sh
+```
+
+or
+
+```
+create_two_vms.sh  → push to master  → app live  → azure-teardown.sh
+```
+
+## Prerequisites
+
+Install and configure on your local machine:
+
+- **Azure CLI** (`az`) — logged in with `az login`
+- **GitHub CLI** (`gh`) — logged in with `gh auth login`
+- **SSH key pair** at `~/.ssh/id_rsa` / `~/.ssh/id_rsa.pub`
+  (override with `SSH_KEY_PATH` / `SSH_PUB_KEY_PATH` env vars)
+- Access to the `Balladebaderne/cookbook` GitHub repo
+- A **Personal Access Token** with `read:packages` scope available as
+  `CR_PAT` (only needed if you pull images on the VM manually; the
+  pipeline uses the ephemeral `GITHUB_TOKEN`)
+
+## Two deployment topologies
+
+The pipeline in [`.github/workflows/ci-cd.yml`](../.github/workflows/ci-cd.yml)
+reads a repo variable `DEPLOY_MODE` and picks which deploy job to run:
+
+| Mode       | Script                 | VMs                          | Compose file used                                                           |
+| ---------- | ---------------------- | ---------------------------- | --------------------------------------------------------------------------- |
+| `single`   | `create_vm.sh`         | 1 (public)                   | [`docker-compose.single-vm.yml`](../docker-compose.single-vm.yml)           |
+| `two-vms`  | `create_two_vms.sh`    | 2 (public nginx + private backend) | [`docker-compose.nginx.yml`](../docker-compose.nginx.yml) + [`docker-compose.backend.yml`](../docker-compose.backend.yml) |
+
+The create scripts set `DEPLOY_MODE` for you. You only need to pick one
+topology at a time.
+
+## Part 1 — Single VM
+
+```bash
+bash infrastructure/create_vm.sh
+```
+
+What it does:
+
+1. Creates resource group `rg-balladebaderne` in `francecentral`.
+2. Creates one `Standard_B1s` Ubuntu 22.04 VM named `cookbook-vm`.
+3. Opens ports **80, 443, 3000**.
+4. Installs Docker + Compose on the VM over SSH.
+5. Sets repo secrets `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`.
+6. Sets repo variable `DEPLOY_MODE=single`.
+
+Then push to `master` (or run the workflow manually) and the app will
+be live at `http://<VM_IP>`.
+
+## Part 2 — Two VMs
+
+```bash
+bash infrastructure/create_two_vms.sh
+```
+
+What it does:
+
+1. Creates resource group `rg-balladebaderne` in `francecentral`.
+2. Creates a VNet `10.0.0.0/16` with subnet `10.0.1.0/24`.
+3. Creates two `Standard_B1s` VMs: `cookbook-nginx` (public) and
+   `cookbook-backend` (internal).
+4. Opens **80 / 443** on nginx. Restricts backend port **3000** to
+   the nginx VM's private IP only — backend is not reachable from
+   the internet on the app port.
+5. Installs Docker + Compose on both VMs over SSH.
+6. Sets repo secrets `SSH_HOST_NGINX`, `SSH_HOST_BACKEND`,
+   `BACKEND_PRIVATE_IP`, `SSH_USER`, `SSH_PRIVATE_KEY`.
+7. Sets repo variable `DEPLOY_MODE=two-vms`.
+
+Push to `master` and the app will be live at `http://<NGINX_IP>`.
+
+## Teardown
+
+```bash
+bash infrastructure/azure-teardown.sh
+```
+
+Lists every resource in `rg-balladebaderne` and asks you to type the
+resource group name to confirm. On confirmation it issues
+`az group delete --yes --no-wait` — the whole RG and everything in it
+is removed.
+
+After teardown, run the other create script if you want to switch
+topology. The create script will overwrite `DEPLOY_MODE` and any
+stale secrets.
+
+## Switching modes
+
+No teardown strictly required, but simplest flow:
+
+```bash
+bash infrastructure/azure-teardown.sh      # delete current RG
+bash infrastructure/create_vm.sh           # or create_two_vms.sh
+```
+
+## Environment overrides
+
+Every tunable in both scripts is overridable via env var — useful if
+your fork lives under a different owner or you want a different
+location/size:
+
+```bash
+GITHUB_REPO="yourorg/yourfork" \
+RESOURCE_GROUP="rg-mydemo" \
+LOCATION="westeurope" \
+VM_SIZE="Standard_B2s" \
+bash infrastructure/create_vm.sh
+```
+
+See the top of each script for the full list.

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Provisions the two-VM cookbook deployment in Azure and wires up
 # GitHub repo secrets so the CI/CD pipeline can SSH into the VMs.
 #
-# Run interactively the first time:   bash infrastructure/azure-setup.sh
+# Run interactively the first time:   bash infrastructure/create_two_vms.sh
 # Safe to re-run: resource creation is idempotent; existing resources are reused.
 
 RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
@@ -85,7 +85,10 @@ log "Opening ports 80 and 443 on '$NGINX_VM'..."
 az vm open-port --resource-group "$RESOURCE_GROUP" --name "$NGINX_VM" --port 80  --priority 1001 --output none || true
 az vm open-port --resource-group "$RESOURCE_GROUP" --name "$NGINX_VM" --port 443 --priority 1002 --output none || true
 
-log "Allowing backend port $BACKEND_PORT from VNet ($VNET_CIDR) only on '$BACKEND_VM'..."
+NGINX_PRIVATE_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$NGINX_VM" --query privateIps -o tsv)
+[[ -n "$NGINX_PRIVATE_IP" ]] || die "Could not resolve nginx private IP"
+
+log "Allowing backend port $BACKEND_PORT from nginx ($NGINX_PRIVATE_IP) only on '$BACKEND_VM'..."
 BACKEND_NSG=$(az vm show -g "$RESOURCE_GROUP" -n "$BACKEND_VM" \
   --query "networkProfile.networkInterfaces[0].id" -o tsv \
   | xargs -I{} az network nic show --ids {} --query "networkSecurityGroup.id" -o tsv)
@@ -96,15 +99,31 @@ if [[ -z "$BACKEND_NSG" ]]; then
 fi
 [[ -n "$BACKEND_NSG" ]] || die "Could not locate NSG for $BACKEND_VM"
 
+BACKEND_NSG_NAME="$(basename "$BACKEND_NSG")"
+
+# If a prior run created a broader rule, drop it so we end up with the stricter one.
+az network nsg rule delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$BACKEND_NSG_NAME" \
+  --name "allow-backend-from-vnet" \
+  --output none 2>/dev/null || true
+
 az network nsg rule create \
   --resource-group "$RESOURCE_GROUP" \
-  --nsg-name "$(basename "$BACKEND_NSG")" \
-  --name "allow-backend-from-vnet" \
+  --nsg-name "$BACKEND_NSG_NAME" \
+  --name "allow-backend-from-nginx" \
   --priority 1100 \
-  --source-address-prefixes "$VNET_CIDR" \
+  --source-address-prefixes "$NGINX_PRIVATE_IP" \
   --destination-port-ranges "$BACKEND_PORT" \
   --access Allow --protocol Tcp --direction Inbound \
-  --output none 2>/dev/null || log "Rule 'allow-backend-from-vnet' already exists."
+  --output none 2>/dev/null || \
+az network nsg rule update \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$BACKEND_NSG_NAME" \
+  --name "allow-backend-from-nginx" \
+  --source-address-prefixes "$NGINX_PRIVATE_IP" \
+  --destination-port-ranges "$BACKEND_PORT" \
+  --output none
 
 # ---------- IP lookup ----------
 log "Fetching IP addresses..."
@@ -173,6 +192,9 @@ set_secret SSH_HOST_NGINX      "$NGINX_IP"
 set_secret SSH_HOST_BACKEND    "$BACKEND_IP"
 set_secret BACKEND_PRIVATE_IP  "$BACKEND_PRIVATE_IP"
 gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
+
+log "Setting deploy-mode variable to 'two-vms' on $GITHUB_REPO..."
+gh variable set DEPLOY_MODE --body "two-vms" -R "$GITHUB_REPO"
 
 log "Done."
 cat <<SUMMARY

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provisions the single-VM cookbook deployment in Azure and wires up
+# GitHub repo secrets so the CI/CD pipeline can SSH into the VM.
+#
+# Run interactively the first time:   bash infrastructure/create_vm.sh
+# Safe to re-run: resource creation is idempotent; existing resources are reused.
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
+LOCATION="${LOCATION:-francecentral}"
+
+VM_NAME="${VM_NAME:-cookbook-vm}"
+VM_SIZE="${VM_SIZE:-Standard_B1s}"
+VM_IMAGE="Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
+ADMIN_USER="${ADMIN_USER:-azureuser}"
+SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-$HOME/.ssh/id_rsa.pub}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/id_rsa}"
+
+GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
+
+APP_PORT=3000
+
+log() { printf '\n\033[1;34m[setup]\033[0m %s\n' "$*"; }
+die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v az >/dev/null || die "Azure CLI (az) not installed."
+command -v gh >/dev/null || die "GitHub CLI (gh) not installed."
+command -v ssh >/dev/null || die "ssh not installed."
+[[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
+[[ -f "$SSH_KEY_PATH" ]] || die "SSH private key not found at $SSH_KEY_PATH"
+
+log "Verifying Azure login..."
+az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+ACCOUNT_NAME=$(az account show --query name -o tsv)
+log "Azure account: $ACCOUNT_NAME"
+
+log "Verifying GitHub login..."
+gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+
+# ---------- Resource group ----------
+log "Creating resource group '$RESOURCE_GROUP' in $LOCATION..."
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION" --output none
+
+# ---------- VM ----------
+log "Creating VM '$VM_NAME'..."
+if az vm show -g "$RESOURCE_GROUP" -n "$VM_NAME" >/dev/null 2>&1; then
+  log "VM '$VM_NAME' already exists, skipping create."
+else
+  az vm create \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$VM_NAME" \
+    --image "$VM_IMAGE" \
+    --size "$VM_SIZE" \
+    --admin-username "$ADMIN_USER" \
+    --ssh-key-values "$SSH_PUB_KEY_PATH" \
+    --public-ip-sku Standard \
+    --output none
+fi
+
+# ---------- NSG rules ----------
+log "Opening ports 80, 443, and $APP_PORT on '$VM_NAME'..."
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 80        --priority 1001 --output none || true
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 443       --priority 1002 --output none || true
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port "$APP_PORT" --priority 1003 --output none || true
+
+# ---------- IP lookup ----------
+log "Fetching IP address..."
+VM_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$VM_NAME" --query publicIps -o tsv)
+log "  VM public IP: $VM_IP"
+
+# ---------- Provision VM over SSH ----------
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i "$SSH_KEY_PATH")
+
+wait_for_ssh() {
+  local host="$1"
+  log "Waiting for SSH on $host..."
+  for _ in $(seq 1 30); do
+    if ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$host" 'true' 2>/dev/null; then
+      return 0
+    fi
+    sleep 5
+  done
+  die "SSH never came up on $host"
+}
+
+wait_for_ssh "$VM_IP"
+log "Provisioning VM ($VM_IP): base packages + Docker..."
+ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$VM_IP" 'bash -s' <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+sudo -E apt-get update -y
+sudo -E apt-get upgrade -y
+sudo -E apt-get install -y curl wget git unzip ca-certificates gnupg lsb-release
+
+if ! command -v docker >/dev/null 2>&1; then
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo -E apt-get update -y
+  sudo -E apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo usermod -aG docker "$USER"
+fi
+sudo systemctl enable --now docker
+mkdir -p "$HOME/app"
+REMOTE
+
+# ---------- GitHub secrets ----------
+log "Setting GitHub secrets on $GITHUB_REPO..."
+set_secret() {
+  # NB: `--body -` would literally store the string "-"; omit --body so gh
+  # reads the value from stdin instead.
+  printf '%s' "$2" | gh secret set "$1" -R "$GITHUB_REPO"
+}
+
+set_secret SSH_USER "$ADMIN_USER"
+set_secret SSH_HOST "$VM_IP"
+gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
+
+log "Setting deploy-mode variable to 'single' on $GITHUB_REPO..."
+gh variable set DEPLOY_MODE --body "single" -R "$GITHUB_REPO"
+
+log "Done."
+cat <<SUMMARY
+
+Single-VM deployment provisioned:
+  Resource group: $RESOURCE_GROUP
+  VM:             $VM_NAME ($VM_IP)
+  Open ports:     80, 443, $APP_PORT
+
+GitHub secrets set on $GITHUB_REPO:
+  SSH_USER, SSH_HOST, SSH_PRIVATE_KEY
+
+Push to master to trigger the deploy pipeline.
+SUMMARY

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,8 +10,6 @@ info:
 servers:
   - url: http://localhost:3000
     description: Local development server
-  - url: http://172.189.59.40
-    description: Production server (Azure VM)
 
 tags:
   - name: Health


### PR DESCRIPTION
## Summary
- Add `infrastructure/create_vm.sh` for Part 1 single-VM setup; rename `azure-setup.sh` → `create_two_vms.sh`
- Gate `ci-cd.yml` deploy jobs on `vars.DEPLOY_MODE` so the pipeline picks the right topology automatically
- Tighten backend NSG: app port allowed from nginx private IP only (was whole VNet)
- Add `docker-compose.single-vm.yml` and `infrastructure/README.md`; rewrite root `README.md`

## Checklist status
- [x] `infrastructure/create_vm.sh` (Part 1)
- [x] `infrastructure/create_two_vms.sh` (Part 2)
- [x] `infrastructure/azure-teardown.sh` (unchanged)
- [x] `infrastructure/README.md` covering prereqs / setup / teardown
- [ ] Full-cycle test (each member runs setup → deploy → teardown) — requires humans

## Test plan
- [ ] Run `bash infrastructure/create_two_vms.sh` and confirm app is live via nginx public IP, backend port 3000 blocked externally
- [ ] `bash infrastructure/azure-teardown.sh` deletes the RG
- [ ] `bash infrastructure/create_vm.sh` provisions single VM, app live via VM IP, ports 80/443/3000 open
- [ ] Verify `DEPLOY_MODE` repo variable is set correctly after each create script
- [ ] Confirm `push → master` triggers correct deploy job; wrong-mode job is skipped

## Follow-up
After merging into `dev`, open a standard `dev → master` PR to ship.