### PR TITLE
feat: complete infra checklist (hardening + team-safety) + AI agent guardrails

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# GitHub Copilot Instructions
+
+The authoritative guardrails for AI contributions to this repository live in
+**[`AGENTS.md`](../AGENTS.md)** at the repo root. Read that file before suggesting changes.
+
+Repository: <https://github.com/Balladebaderne/cookbook>
+
+Copilot-specific quick rules (full rules in `AGENTS.md`):
+
+- **Never** suggest direct commits or pushes to `master`. It is PR-only because merging to `master` auto-deploys to the Azure VM.
+- Pushes to `dev` are allowed — but prefer a feature branch for anything non-trivial.
+- Feature branches branch from `dev` and merge back into `dev`.
+- Hotfix branches branch from `master`, open a PR back to `master`, and are back-merged into `dev`.
+- Release branches branch from `dev`, open a PR to `master`, and are back-merged into `dev`.
+- Local development runs through Docker Compose with the `dev` profile, not raw `node` / `vite`.
+- Before any push, `bash scripts/security-check.sh` must pass (npm audit + secret scan + forbidden-file check).
+- Do not suggest committing `.env`, `*.db`, `*.pem`, `node_modules/`, or `dist/`.
+- Do not suggest edits to `.github/workflows/`, `infrastructure/`, or `legacy/` without an explicit request for that area.
+- `openapi.yaml` is the API contract — keep it in sync with backend handler changes in the same commit.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -155,12 +155,18 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.SSH_HOST_BACKEND }} >> ~/.ssh/known_hosts
 
+      # Backend has no public IP; reach it via nginx as an SSH jump host.
+      # StrictHostKeyChecking is off because we can't keyscan a private host
+      # from the GitHub runner, and the jump host's key isn't cached either.
       - name: Copy backend compose file
         run: |
-          scp -i ~/.ssh/id_rsa docker-compose.backend.yml \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_BACKEND }}:~/app/docker-compose.yml
+          scp -i ~/.ssh/id_rsa \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            docker-compose.backend.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }}:~/app/docker-compose.yml
 
       - name: Pull and start backend container
         env:
@@ -168,7 +174,10 @@ jobs:
         run: |
           OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
           ssh -i ~/.ssh/id_rsa \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_BACKEND }} \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }} \
             "cd ~/app && \
              echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
              GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,11 +94,53 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  deploy-single-vm:
+    name: Deploy to single VM
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: |
+      vars.DEPLOY_MODE == 'single' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Copy compose file
+        run: |
+          scp -i ~/.ssh/id_rsa docker-compose.single-vm.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose.yml
+
+      - name: Pull and start containers
+        env:
+          OWNER_LC: ${{ github.repository_owner }}
+        run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"
+
   deploy-backend:
     name: Deploy backend to Azure VM
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    if: |
+      vars.DEPLOY_MODE == 'two-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
 
     permissions:
       contents: read
@@ -136,7 +178,9 @@ jobs:
     name: Deploy nginx to Azure VM
     runs-on: ubuntu-latest
     needs: [build-and-push, deploy-backend]
-    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    if: |
+      vars.DEPLOY_MODE == 'two-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
 
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,242 @@
+# AGENTS.md — Guardrails for AI Coding Agents
+
+> **Canonical rules for any AI agent (Claude Code, Codex, Cursor, Copilot, Jules, etc.) working in this repository.**
+> If you are an AI agent, you MUST read this file top-to-bottom **before** reading any other file and before making any change. Human contributors may read it too — it doubles as onboarding.
+
+Repository: <https://github.com/Balladebaderne/cookbook>
+
+---
+
+## 0. Prime directive: understand before you act
+
+Before proposing, writing, or running anything, an agent MUST complete this pre-flight checklist. No exceptions — not even for "tiny" changes.
+
+1. Read `README.md` at the repo root.
+2. Read **this file** (`AGENTS.md`) in full.
+3. Read `openapi.yaml` — it is the source of truth for the backend API contract.
+4. Check the current git state:
+   ```bash
+   git branch --show-current
+   git status
+   git log --oneline -10
+   ```
+5. Read `backend/package.json` and `frontend/package.json` to know what runtime + deps exist.
+6. Read the Docker Compose file(s) relevant to the task:
+   - Local work → `docker-compose.yml` (profile `dev`)
+   - Single-VM prod → `docker-compose.single-vm.yml`
+   - Two-VM prod → `docker-compose.nginx.yml` + `docker-compose.backend.yml`
+7. If the task touches CI/CD or deploy, read `.github/workflows/ci-cd.yml` first.
+8. Summarize back to the human what you understood and what you intend to do **before** touching files. Wait for confirmation on anything non-trivial.
+
+If any of the above files are missing or contradictory, stop and ask. Do not guess.
+
+---
+
+## 1. Project at a glance
+
+**Cookbook** is a full-stack recipe app.
+
+| Layer          | Tech                                                    |
+| -------------- | ------------------------------------------------------- |
+| Backend        | Node.js 18, Express, SQLite3, OpenAPI 3.0 (swagger-ui)  |
+| Frontend       | React 19 (Vite), react-three/fiber, served by nginx     |
+| Infra          | Azure VMs (Ubuntu 22.04), Docker, Docker Compose        |
+| CI/CD          | GitHub Actions → GHCR → SSH deploy to VM                |
+
+Two deploy topologies live side-by-side:
+- **Single VM** — one host runs both containers (`docker-compose.single-vm.yml`)
+- **Two VMs** — public nginx host + internal backend host (`docker-compose.nginx.yml` + `docker-compose.backend.yml`)
+
+Which one ships is controlled by the repo variable `DEPLOY_MODE` (`single` or `two-vms`).
+
+The `legacy/` folder contains an old Python/Flask implementation kept for reference. **Do not modify `legacy/`** unless the human explicitly asks.
+
+---
+
+## 2. Git flow — this is non-negotiable
+
+We use Git Flow. The **critical rule** is that **merging into `master` is what triggers production deployment**, so `master` is gated behind a pull request. `dev` is the shared integration branch — pushes there are allowed, but feature work should still go through feature branches whenever practical.
+
+```
+master   ──●───────────────●──────●──→  (production — PR-only, auto-deploys)
+            \             / \    /
+hotfix       \           /   ●──/  (branch from master, PR to master + back-merge to dev)
+              \         /
+release        \       ●──●        (branch from dev, PR to master + back-merge to dev)
+                \     /    \
+dev   ──●───●───●───●──────●──→    (integration — CI builds, no deploy)
+         \     / \
+feature   ●───●   ●──●──●          (branch from dev, merge back into dev)
+```
+
+### Branch rules
+
+| Branch        | Branches from   | Merges into           | PR required?                 |
+| ------------- | --------------- | --------------------- | ---------------------------- |
+| `master`      | —               | —                     | **Yes — always.** No direct pushes, ever. |
+| `dev`         | `master` (init) | —                     | Not required. Direct pushes allowed. |
+| `feature/*`   | `dev`           | `dev`                 | Optional — team preference. Fast-forward / squash merge is fine. |
+| `release/*`   | `dev`           | `master` **and** `dev` | **Yes** — for the master side. |
+| `hotfix/*`    | `master`        | `master` **and** `dev` | **Yes** — for the master side. |
+
+### Why `master` is strict and `dev` is not
+
+- A push to `master` triggers the deploy job in `ci-cd.yml`, which SSHes into the Azure VM and restarts containers. Mistakes there are user-visible.
+- A push to `dev` only triggers `security-audit` and `build-and-push` — the images get tagged but nothing deploys. It's our integration playground.
+
+### Agent rules around git flow
+
+- **Never** `git push` (or propose a push) to `master`. Ever. The only way code reaches `master` is via a merged PR.
+- Pushes to `dev` are allowed, but **prefer the feature-branch route** for anything non-trivial: branch from `dev`, do the work, merge back to `dev`.
+- For hotfixes: branch from `master`, open a PR back to `master`, and after it merges, cherry-pick or merge the same commits into `dev` so the two branches don't diverge.
+- For releases: branch from `dev` as `release/<semver>`, stabilize, open a PR to `master`, then back-merge to `dev`.
+- If the current branch is `master` and the user asks for code changes, switch before editing:
+  ```bash
+  git checkout dev && git pull
+  git checkout -b feature/<slug>   # or hotfix/<slug> depending on intent
+  ```
+- Before creating a branch, ask the human for the name if it wasn't given, and confirm the base (`dev` for feature/release, `master` for hotfix).
+
+### Branch naming
+
+- `feature/<short-kebab-slug>` — e.g. `feature/add-recipe-tags`
+- `hotfix/<short-kebab-slug>` — e.g. `hotfix/null-recipe-id`
+- `release/<semver>` — e.g. `release/1.2.0`
+
+---
+
+## 3. Local development workflow
+
+We test locally with Docker, **not** raw `npm start`. The `dev` profile of the root compose file is the canonical way.
+
+```bash
+# Start (from repo root)
+docker compose --profile dev up -d --build
+
+# Tail logs
+docker compose --profile dev logs -f
+
+# Stop
+docker compose --profile dev down
+```
+
+Endpoints:
+- Frontend: <http://localhost>
+- Backend API: <http://localhost:3000/api>
+- Swagger UI: <http://localhost:3000/apidocs>
+
+**Agent rules:**
+- Prefer Docker for running the app. Do not start raw `node` or `vite dev` servers unless debugging a specific issue that requires it, and only after telling the human.
+- If you change a `Dockerfile`, `package.json`, or `docker-compose*.yml`, you MUST rebuild with `--build` and verify the stack still comes up clean before handing back.
+- If you change the SQLite schema in `backend/initDb.js`, mention that local volumes may need to be wiped (`docker compose --profile dev down -v`) and flag this in the PR / commit message.
+
+---
+
+## 4. Security gate — run this before every push
+
+The CI pipeline runs `npm audit --audit-level=high` on both packages. That's the backstop, not the first line of defense. The agent MUST run a local security check **before** every `git push` — including pushes to `dev` — and the check must pass.
+
+A helper script is provided:
+
+```bash
+bash scripts/security-check.sh
+```
+
+### What it checks (enforced)
+
+1. **Branch check** — hard-fails if the current branch is `master`. Warns on `main`/`dev`/`develop` or on non-git-flow names.
+2. **Forbidden files** — blocks if any of these are tracked or staged:
+   - `node_modules/`, `dist/`, `build/`
+   - `*.db`, `*.sqlite`, `*.sqlite3`, `*.db-journal`
+   - `.env`, `.env.*` (but `.env.example` is allowed)
+   - `*.pem`, `*.key`, `id_rsa*`
+   - `docker-compose.override.yml`
+3. **Secret pattern scan** — blocks on:
+   - `-----BEGIN (RSA|OPENSSH|EC|DSA|PGP) PRIVATE KEY-----`
+   - AWS access keys (`AKIA...`)
+   - GitHub PATs (`ghp_...`, `github_pat_...`)
+   - Slack tokens (`xox[baprs]-...`)
+   - Generic assignments like `password = "..."`, `api_key = "..."` with non-placeholder values
+4. **Dependency audit** — `npm audit --audit-level=high` in `backend/` AND `frontend/`. Any `high` or `critical` blocks the push.
+5. **Dockerfile sanity** — warns on unpinned base images, `ADD http...`, or `curl | sh` patterns.
+6. **.gitignore present** — warns if absent or clearly weakened.
+
+### On any failure
+
+- Do not push.
+- Report which check failed, with the exact offending file/line.
+- Propose a fix. If the fix needs a human decision (e.g. a `high` vuln with no patched version), surface it and wait for instruction.
+- **Never** bypass with `git push --no-verify` or by lowering `--audit-level`.
+
+### Recommended: wire it up as a pre-push hook
+
+```bash
+# One-time setup
+cp scripts/security-check.sh .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+---
+
+## 5. Pull requests
+
+- **To `master`:** always via PR, always from a `release/*` or `hotfix/*` branch (or, exceptionally, `dev` itself for a coordinated release merge). This PR is what ships to the VM — treat it as the deploy button.
+- **To `dev`:** no PR required. Direct pushes or feature-branch merges both fine. Still run the security check first.
+- Use the repo's `PULL_REQUEST_TEMPLATE.md`. Fill in **all** three sections (what / why / how tested).
+- A PR that changes CI/CD (`.github/workflows/**`), infra (`infrastructure/**`), or any `Dockerfile` requires an explicit note in the PR body calling that out. The agent should never sneak these in alongside feature work.
+- Agents should open PRs to `master` as **draft** by default, and only mark ready once the local security check and the CI `security-audit` job both pass cleanly.
+
+---
+
+## 6. Hard nevers (agent refuses even if asked)
+
+- Push, force-push, or rebase `master`.
+- Commit secrets, `.env` files, private keys, or the SQLite DB.
+- Commit `node_modules/` or `dist/`.
+- Modify `.github/workflows/ci-cd.yml`, `infrastructure/*.sh`, or the prod compose files without an explicit, in-conversation approval from the human for that specific change.
+- Edit anything under `legacy/` unless explicitly told to.
+- Weaken `.gitignore`, disable `npm audit` in CI, or lower `--audit-level`.
+- Use `git commit --no-verify` or `git push --no-verify` to bypass hooks.
+- Echo, log, or otherwise surface the contents of `~/.ssh/`, `secrets.*`, or CI secrets.
+- Add new top-level dependencies without running `npm audit` on the result and reporting the delta.
+
+If the human asks for one of these, the agent should refuse, explain which rule applies, and propose the correct path (e.g. "I can't push to master, but I can open a PR from `release/1.2.0` into `master`").
+
+---
+
+## 7. Commit messages
+
+Short, imperative, present tense. Conventional Commits preferred but not mandatory.
+
+```
+feat(backend): add GET /api/recipe/:id/tags
+fix(frontend): null-check recipe author on list view
+chore(ci): bump setup-node to v4
+```
+
+One logical change per commit. Don't mix formatting with logic.
+
+---
+
+## 8. Adding or updating dependencies
+
+1. Work on a feature branch (or `dev` for small bumps).
+2. `npm install <pkg>` (or `npm install <pkg>@<exact>` — prefer exact versions for new direct deps).
+3. Commit **both** `package.json` and `package-lock.json`.
+4. Run `npm audit --audit-level=high` in that package — it must pass.
+5. Run `bash scripts/security-check.sh` from repo root.
+6. Note the dep (name, version, why) in the commit message or PR description.
+
+In CI we use `npm ci`, not `npm install` — don't change that.
+
+---
+
+## 9. API contract
+
+`openapi.yaml` at the repo root is the **source of truth** for the HTTP API. If you change an endpoint, update the spec in the same commit as the handler. Swagger UI at `/apidocs` serves this file directly, so a drift between code and spec is a user-visible bug.
+
+---
+
+## 10. When in doubt
+
+Stop. Ask. A thirty-second clarification beats a thirty-minute revert.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md
+
+This file exists so Claude Code picks up the project's AI-agent guardrails.
+
+**→ The canonical rules live in [`AGENTS.md`](./AGENTS.md). Read that file first, in full, before doing anything in this repo.**
+
+Repository: <https://github.com/Balladebaderne/cookbook>
+
+Short summary (authoritative version is `AGENTS.md`):
+
+- **Understand before acting.** Read `README.md`, `AGENTS.md`, `openapi.yaml`, and check `git status` / `git branch --show-current` before editing anything.
+- **Git Flow.** Feature branches from `dev`, hotfix branches from `master`. Merges to `dev` can be direct pushes or PRs — your choice. **Merges to `master` are always PR-only** because `master` auto-deploys to the VM.
+- **Local dev uses Docker.** `docker compose --profile dev up -d --build` — not raw `npm start`.
+- **Security gate before every push.** Run `bash scripts/security-check.sh`. It must pass. No `--no-verify`, no audit bypass.
+- **Never commit:** secrets, `.env`, `*.db`, `*.pem`, `node_modules/`, `dist/`.
+- **Never modify** `.github/workflows/`, `infrastructure/`, or `legacy/` without explicit approval.
+- **Never push to `master`.** The only way in is a merged PR.
+
+When any of the rules in `AGENTS.md` conflict with a user request, follow `AGENTS.md` and explain why.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ All Azure provisioning lives under [`infrastructure/`](./infrastructure/README.m
 Two topologies are supported — pick one:
 
 - **Single VM** — `bash infrastructure/create_vm.sh`
-- **Two VMs** (public nginx + internal backend) — `bash infrastructure/create_two_vms.sh`
+- **Two VMs** (public nginx + backend with **no public IP**, reachable
+  only through nginx) — `bash infrastructure/create_two_vms.sh`
 
 The create scripts set the repo variable `DEPLOY_MODE` so the CI/CD
 pipeline knows which deploy job to run. Push to `master` (or trigger
@@ -57,8 +58,14 @@ pipeline knows which deploy job to run. Push to `master` (or trigger
 bash infrastructure/azure-teardown.sh
 ```
 
-See [`infrastructure/README.md`](./infrastructure/README.md) for
-prerequisites, secrets, and the full cycle.
+### Only one live deployment at a time
+
+The repo's deploy secrets and `DEPLOY_MODE` variable are shared team
+state — running `create_*.sh` overwrites them. The scripts enforce
+this by recording a `DEPLOY_OWNER` variable on the repo and refusing
+to run when someone else owns the current deployment. Teardown clears
+the lock. See [`infrastructure/README.md`](./infrastructure/README.md#one-active-deployment-at-a-time)
+for the full flow and the `FORCE=1` override.
 
 ## Pipeline Overview
 
@@ -71,7 +78,18 @@ prerequisites, secrets, and the full cycle.
 3. **deploy** — only on `master` or manual dispatch. Picks one path
    based on the `DEPLOY_MODE` repo variable:
    - `single` → SSHs to `SSH_HOST`, runs `docker-compose.single-vm.yml`
-   - `two-vms` → SSHs to backend + nginx VMs with their respective compose files
+   - `two-vms` → SSHs to nginx directly, and to backend via nginx as
+     an SSH jump host (backend has no public IP), each with its own
+     compose file
+
+## For contributors
+
+See [`AGENTS.md`](./AGENTS.md) for branching rules, the security gate,
+and do-not-touch paths. One-time hook install per clone:
+
+```bash
+cp scripts/security-check.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+```
 
 ## Repository
 

--- a/README.md
+++ b/README.md
@@ -1,220 +1,77 @@
-# Cookbook - Recipe Management Application
+# Cookbook — Recipe Management Application
 
-A full-stack recipe management web application where users can browse, view, and manage recipes.
-
-The application is deployed on an Azure Virtual Machine using Docker and is accessible online.
-
----
-
-## Live Deployments
-
-**Frontend:**  
-http://172.189.59.40
-
-**Backend API:**  
-http://172.189.59.40/api
-
-**API Documentation (Swagger):**  
-http://172.189.59.40/apidocs/
-
----
+A full-stack recipe management web application where users can browse,
+view, and manage recipes. Deployed on Azure VMs via Docker and GitHub
+Actions.
 
 ## Tech Stack
 
-### Backend
-- Node.js
-- Express.js
-- SQLite3
-- OpenAPI 3.0 (Swagger)
-
-### Frontend
-- React
-- Nginx (served via Docker)
-
-### Infrastructure
-- Azure Virtual Machine (Ubuntu)
-- Docker
-- Docker Compose
-- GitHub Actions
-- GitHub Container Registry (GHCR)
-
-### DevOps & Version Control
-- Git
-- GitHub
-
----
+**Backend:** Node.js, Express, SQLite3, OpenAPI 3.0 (Swagger)
+**Frontend:** React (Vite), served by Nginx
+**Infrastructure:** Azure VMs (Ubuntu 22.04), Docker, Docker Compose,
+GitHub Actions, GitHub Container Registry
 
 ## Project Structure
 
 ```text
 cookbook/
-|-- backend/                  # Express backend API
-|   |-- index.js
-|   |-- package.json
-|   `-- Dockerfile
-|-- frontend/                 # React frontend
-|   |-- src/
-|   |-- package.json
-|   |-- nginx.conf
-|   `-- Dockerfile
-|-- docker-compose.yml        # Local development with image builds
-|-- docker-compose.prod.yml   # Production deployment with GHCR images
-|-- openapi.yaml              # OpenAPI specification
-`-- README.md
+├── backend/                      # Express API + Dockerfile
+├── frontend/                     # React + nginx Dockerfile
+├── infrastructure/               # Azure provisioning scripts
+│   ├── create_vm.sh              # single-VM setup
+│   ├── create_two_vms.sh         # two-VM (nginx + backend) setup
+│   ├── azure-teardown.sh         # deletes the resource group
+│   └── README.md
+├── docker-compose.yml            # local dev
+├── docker-compose.single-vm.yml  # prod: single VM
+├── docker-compose.nginx.yml      # prod: two-VM, nginx host
+├── docker-compose.backend.yml    # prod: two-VM, backend host
+├── openapi.yaml
+└── .github/workflows/ci-cd.yml
 ```
 
----
-
-## Running Locally with Docker
-
-### Requirements
-
-- Docker
-- Docker Compose
-
-### Start application
+## Running Locally
 
 ```bash
-docker compose up -d --build
+docker compose --profile dev up -d --build   # start
+docker compose --profile dev down            # stop
 ```
 
-### Stop application
+- Frontend: http://localhost
+- Backend API: http://localhost:3000/api
+- Swagger: http://localhost:3000/apidocs
+
+## Deploying to Azure
+
+All Azure provisioning lives under [`infrastructure/`](./infrastructure/README.md).
+Two topologies are supported — pick one:
+
+- **Single VM** — `bash infrastructure/create_vm.sh`
+- **Two VMs** (public nginx + internal backend) — `bash infrastructure/create_two_vms.sh`
+
+The create scripts set the repo variable `DEPLOY_MODE` so the CI/CD
+pipeline knows which deploy job to run. Push to `master` (or trigger
+`workflow_dispatch`) to deploy. Tear down with:
 
 ```bash
-docker compose down
+bash infrastructure/azure-teardown.sh
 ```
 
-### Access locally
+See [`infrastructure/README.md`](./infrastructure/README.md) for
+prerequisites, secrets, and the full cycle.
 
-Frontend:  
-http://localhost
+## Pipeline Overview
 
-Backend API:  
-http://localhost:3000/api
+[`ci-cd.yml`](./.github/workflows/ci-cd.yml) runs on push to
+`master`/`dev` and on `workflow_dispatch`:
 
-Swagger docs:  
-http://localhost:3000/apidocs
-
----
-
-## Current Pipeline Overview
-
-The repository currently deploys from GitHub Actions. The workflow is defined in [`.github/workflows/ci-cd.yml`](./.github/workflows/ci-cd.yml).
-
-### How it works now
-
-1. A push to `master` or `dev` starts the pipeline.
-2. The `build` job installs dependencies and runs lint, tests, and build steps for both `backend` and `frontend`.
-3. On `master`, the workflow publishes Docker images to GitHub Container Registry:
-   - `ghcr.io/<owner>/cookbook-backend:latest`
-   - `ghcr.io/<owner>/cookbook-frontend:latest`
-4. The deploy job then SSHs into the VM using GitHub Secrets.
-5. The VM logs into `ghcr.io`, pulls the latest images, and starts them with `docker compose -f docker-compose.prod.yml up -d`.
-
-### Which secrets are involved
-
-The pipeline still depends on GitHub Secrets for access:
-
-- `SSH_PRIVATE_KEY`: private key used by GitHub Actions to SSH into the VM
-- `SSH_HOST`: public IP or DNS name of the VM
-- `SSH_USER`: SSH username on the VM, likely `azureuser`
-- `DEPLOY_PATH`: directory on the VM where the production compose file lives
-- `GHCR_USERNAME`: GitHub username or machine user with package read access
-- `GHCR_PAT`: GitHub token with permission to read packages from GHCR
-
-### Important difference
-
-The VM no longer needs the full repository copied onto it for deployment. It only needs:
-
-- Docker and Docker Compose installed
-- access to `ghcr.io`
-- the production compose file
-- a GitHub token that can pull the package images
-
----
-
-## Azure VM Access
-
-### What we know from this repository
-
-The repository documents:
-
-- SSH user: `azureuser`
-- public IP: `172.189.59.40`
-
-That means the expected login command is:
-
-```bash
-ssh azureuser@172.189.59.40
-```
-
-### What is not stored in this repository
-discovered people in the project and commited a change
-
-### Update application from GitHub
-
-This repo does **not** contain Azure infrastructure files such as Terraform, Bicep, or ARM templates, so it does not tell us:
-
-- the Azure resource group
-- the VM name in Azure
-- the Azure subscription
-- whether a DNS name is configured
-
-You would need to check one of these places for that:
-
-- the Azure Portal
-- repository or organization secrets in GitHub
-- whoever created the VM
-
-### If SSH fails
-
-Common reasons:
-
-- your local machine does not have the correct private key
-- port `22` is blocked in the VM network security group
-- `azureuser` is not the right user anymore
-- the VM public IP has changed
-
----
-
-## VM Deployment Layout
-
-The production deployment now expects a directory like this on the VM:
-
-```text
-<DEPLOY_PATH>/
-|-- .env
-`-- docker-compose.prod.yml
-```
-
-The `.env` file is written by the workflow and includes:
-
-```env
-GITHUB_REPOSITORY_OWNER=<owner>
-IMAGE_TAG=latest
-```
-
----
-
-## Manual Commands On The VM
-
-If you SSH into the VM and want to update the running app manually:
-
-```bash
-cd <DEPLOY_PATH>
-echo "<GHCR_PAT>" | docker login ghcr.io -u "<GHCR_USERNAME>" --password-stdin
-docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml up -d
-```
-
-To inspect what is running:
-
-```bash
-docker compose -f docker-compose.prod.yml ps
-docker images | grep cookbook
-```
-
----
+1. **security-audit** — `npm audit` on backend + frontend.
+2. **build-and-push** — builds backend + frontend images, pushes to
+   `ghcr.io/balladebaderne/cookbook-{backend,frontend}`.
+3. **deploy** — only on `master` or manual dispatch. Picks one path
+   based on the `DEPLOY_MODE` repo variable:
+   - `single` → SSHs to `SSH_HOST`, runs `docker-compose.single-vm.yml`
+   - `two-vms` → SSHs to backend + nginx VMs with their respective compose files
 
 ## Repository
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The application is deployed on an Azure Virtual Machine using Docker and is acce
 
 ---
 
-## Live Deployment
+## Live Deployments
 
 **Frontend:**  
 http://172.189.59.40

--- a/docker-compose.single-vm.yml
+++ b/docker-compose.single-vm.yml
@@ -1,0 +1,40 @@
+services:
+  backend:
+    image: ghcr.io/${GITHUB_OWNER}/cookbook-backend:latest
+    container_name: cookbook-backend
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DB_PATH=/app/data/app.db
+    volumes:
+      - cookbook_data:/app/data
+    networks:
+      - cookbook-network
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  frontend:
+    image: ghcr.io/${GITHUB_OWNER}/cookbook-frontend:latest
+    container_name: cookbook-frontend
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    environment:
+      - BACKEND_HOST=backend:3000
+    depends_on:
+      - backend
+    networks:
+      - cookbook-network
+
+volumes:
+  cookbook_data:
+    driver: local
+
+networks:
+  cookbook-network:
+    driver: bridge

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -29,6 +29,34 @@ Install and configure on your local machine:
   `CR_PAT` (only needed if you pull images on the VM manually; the
   pipeline uses the ephemeral `GITHUB_TOKEN`)
 
+## One active deployment at a time
+
+The repo's deploy secrets (`SSH_HOST*`, `BACKEND_PRIVATE_IP`,
+`SSH_PRIVATE_KEY`) and the `DEPLOY_MODE` variable are **shared team state**.
+Only one teammate can have a live deployment at any moment — the last person
+to run `create_*.sh` owns the deploy target until they (or someone else)
+tear down.
+
+To make this visible and prevent accidents, the create scripts record the
+current owner in a repo variable `DEPLOY_OWNER` (= the GitHub username of
+whoever ran the script). If a classmate tries to run a create script while
+someone else owns the deployment, the script refuses with:
+
+```
+[error] Another teammate already has an active deployment on this repo.
+  Current owner  : alice
+  Deploy mode    : two-vms
+  ...
+```
+
+To release ownership, the current owner runs `bash infrastructure/azure-teardown.sh`
+— that deletes their Azure resources *and* clears `DEPLOY_OWNER` /
+`DEPLOY_MODE` / the deploy secrets from the repo, so the next teammate can
+run a create script without conflict.
+
+If the lock is genuinely stale (VMs already gone but state wasn't cleaned up),
+override with `FORCE=1 bash infrastructure/create_vm.sh`.
+
 ## Two deployment topologies
 
 The pipeline in [`.github/workflows/ci-cd.yml`](../.github/workflows/ci-cd.yml)

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -70,17 +70,20 @@ What it does:
 
 1. Creates resource group `rg-balladebaderne` in `francecentral`.
 2. Creates a VNet `10.0.0.0/16` with subnet `10.0.1.0/24`.
-3. Creates two `Standard_B1s` VMs: `cookbook-nginx` (public) and
-   `cookbook-backend` (internal).
+3. Creates two `Standard_B1s` VMs: `cookbook-nginx` (public IP) and
+   `cookbook-backend` (**no public IP** — only a private VNet address).
 4. Opens **80 / 443** on nginx. Restricts backend port **3000** to
-   the nginx VM's private IP only — backend is not reachable from
-   the internet on the app port.
-5. Installs Docker + Compose on both VMs over SSH.
-6. Sets repo secrets `SSH_HOST_NGINX`, `SSH_HOST_BACKEND`,
-   `BACKEND_PRIVATE_IP`, `SSH_USER`, `SSH_PRIVATE_KEY`.
+   the nginx VM's private IP only.
+5. Installs Docker + Compose on nginx directly and on the backend
+   via nginx as an SSH jump host (`ProxyJump`).
+6. Sets repo secrets `SSH_HOST_NGINX`, `BACKEND_PRIVATE_IP`,
+   `SSH_USER`, `SSH_PRIVATE_KEY`.
 7. Sets repo variable `DEPLOY_MODE=two-vms`.
 
 Push to `master` and the app will be live at `http://<NGINX_IP>`.
+The backend is not reachable from the public internet — no public IP,
+no internet-facing ports. The deploy pipeline reaches it by using
+nginx as an SSH jump host.
 
 ## Teardown
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -20,8 +20,10 @@ Install and configure on your local machine:
 
 - **Azure CLI** (`az`) — logged in with `az login`
 - **GitHub CLI** (`gh`) — logged in with `gh auth login`
-- **SSH key pair** at `~/.ssh/id_rsa` / `~/.ssh/id_rsa.pub`
-  (override with `SSH_KEY_PATH` / `SSH_PUB_KEY_PATH` env vars)
+- **SSH key pair** in `~/.ssh/` — `id_rsa`, `id_ed25519`, or `id_ecdsa`
+  (auto-detected in that order; override with `SSH_KEY_PATH` /
+  `SSH_PUB_KEY_PATH` env vars). If you don't have one yet:
+  `ssh-keygen -t ed25519 -C "you@example.com"`
 - Access to the `Balladebaderne/cookbook` GitHub repo
 - A **Personal Access Token** with `read:packages` scope available as
   `CR_PAT` (only needed if you pull images on the VM manually; the

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,121 @@
+# Infrastructure
+
+Scripts that provision (and tear down) the Azure VMs used to run the
+cookbook app. Every group member should be able to run through a full
+cycle independently:
+
+```
+create_vm.sh  → push to master  → app live  → azure-teardown.sh
+```
+
+or
+
+```
+create_two_vms.sh  → push to master  → app live  → azure-teardown.sh
+```
+
+## Prerequisites
+
+Install and configure on your local machine:
+
+- **Azure CLI** (`az`) — logged in with `az login`
+- **GitHub CLI** (`gh`) — logged in with `gh auth login`
+- **SSH key pair** at `~/.ssh/id_rsa` / `~/.ssh/id_rsa.pub`
+  (override with `SSH_KEY_PATH` / `SSH_PUB_KEY_PATH` env vars)
+- Access to the `Balladebaderne/cookbook` GitHub repo
+- A **Personal Access Token** with `read:packages` scope available as
+  `CR_PAT` (only needed if you pull images on the VM manually; the
+  pipeline uses the ephemeral `GITHUB_TOKEN`)
+
+## Two deployment topologies
+
+The pipeline in [`.github/workflows/ci-cd.yml`](../.github/workflows/ci-cd.yml)
+reads a repo variable `DEPLOY_MODE` and picks which deploy job to run:
+
+| Mode       | Script                 | VMs                          | Compose file used                                                           |
+| ---------- | ---------------------- | ---------------------------- | --------------------------------------------------------------------------- |
+| `single`   | `create_vm.sh`         | 1 (public)                   | [`docker-compose.single-vm.yml`](../docker-compose.single-vm.yml)           |
+| `two-vms`  | `create_two_vms.sh`    | 2 (public nginx + private backend) | [`docker-compose.nginx.yml`](../docker-compose.nginx.yml) + [`docker-compose.backend.yml`](../docker-compose.backend.yml) |
+
+The create scripts set `DEPLOY_MODE` for you. You only need to pick one
+topology at a time.
+
+## Part 1 — Single VM
+
+```bash
+bash infrastructure/create_vm.sh
+```
+
+What it does:
+
+1. Creates resource group `rg-balladebaderne` in `francecentral`.
+2. Creates one `Standard_B1s` Ubuntu 22.04 VM named `cookbook-vm`.
+3. Opens ports **80, 443, 3000**.
+4. Installs Docker + Compose on the VM over SSH.
+5. Sets repo secrets `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`.
+6. Sets repo variable `DEPLOY_MODE=single`.
+
+Then push to `master` (or run the workflow manually) and the app will
+be live at `http://<VM_IP>`.
+
+## Part 2 — Two VMs
+
+```bash
+bash infrastructure/create_two_vms.sh
+```
+
+What it does:
+
+1. Creates resource group `rg-balladebaderne` in `francecentral`.
+2. Creates a VNet `10.0.0.0/16` with subnet `10.0.1.0/24`.
+3. Creates two `Standard_B1s` VMs: `cookbook-nginx` (public) and
+   `cookbook-backend` (internal).
+4. Opens **80 / 443** on nginx. Restricts backend port **3000** to
+   the nginx VM's private IP only — backend is not reachable from
+   the internet on the app port.
+5. Installs Docker + Compose on both VMs over SSH.
+6. Sets repo secrets `SSH_HOST_NGINX`, `SSH_HOST_BACKEND`,
+   `BACKEND_PRIVATE_IP`, `SSH_USER`, `SSH_PRIVATE_KEY`.
+7. Sets repo variable `DEPLOY_MODE=two-vms`.
+
+Push to `master` and the app will be live at `http://<NGINX_IP>`.
+
+## Teardown
+
+```bash
+bash infrastructure/azure-teardown.sh
+```
+
+Lists every resource in `rg-balladebaderne` and asks you to type the
+resource group name to confirm. On confirmation it issues
+`az group delete --yes --no-wait` — the whole RG and everything in it
+is removed.
+
+After teardown, run the other create script if you want to switch
+topology. The create script will overwrite `DEPLOY_MODE` and any
+stale secrets.
+
+## Switching modes
+
+No teardown strictly required, but simplest flow:
+
+```bash
+bash infrastructure/azure-teardown.sh      # delete current RG
+bash infrastructure/create_vm.sh           # or create_two_vms.sh
+```
+
+## Environment overrides
+
+Every tunable in both scripts is overridable via env var — useful if
+your fork lives under a different owner or you want a different
+location/size:
+
+```bash
+GITHUB_REPO="yourorg/yourfork" \
+RESOURCE_GROUP="rg-mydemo" \
+LOCATION="westeurope" \
+VM_SIZE="Standard_B2s" \
+bash infrastructure/create_vm.sh
+```
+
+See the top of each script for the full list.

--- a/infrastructure/azure-teardown.sh
+++ b/infrastructure/azure-teardown.sh
@@ -11,13 +11,18 @@ die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 
 command -v az >/dev/null || die "Azure CLI (az) not installed."
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+ACCOUNT_NAME=$(az account show --query name -o tsv)
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 
 if ! az group show --name "$RESOURCE_GROUP" >/dev/null 2>&1; then
-  log "Resource group '$RESOURCE_GROUP' does not exist. Nothing to do."
+  log "Resource group '$RESOURCE_GROUP' does not exist in subscription '$ACCOUNT_NAME'. Nothing to do."
   exit 0
 fi
 
-log "About to DELETE resource group '$RESOURCE_GROUP' and everything in it:"
+log "About to DELETE resource group '$RESOURCE_GROUP' in:"
+log "  Subscription:    $ACCOUNT_NAME"
+log "  Subscription ID: $SUBSCRIPTION_ID"
+log "Resources that will be removed:"
 az resource list -g "$RESOURCE_GROUP" --query "[].{name:name,type:type}" -o table || true
 
 read -rp $'\nType the resource group name to confirm: ' confirm

--- a/infrastructure/azure-teardown.sh
+++ b/infrastructure/azure-teardown.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # This is destructive and irreversible — requires explicit confirmation.
 
 RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
+GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
 
 log() { printf '\n\033[1;34m[teardown]\033[0m %s\n' "$*"; }
 die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
@@ -31,3 +32,22 @@ read -rp $'\nType the resource group name to confirm: ' confirm
 log "Deleting..."
 az group delete --name "$RESOURCE_GROUP" --yes --no-wait
 log "Delete submitted. Azure will finish in the background."
+
+# ---------- Clear shared deploy state on GitHub ----------
+# Best-effort: the teardown should still succeed even if gh isn't available.
+# This matters because leaving DEPLOY_OWNER / secrets behind blocks the next
+# teammate from running create_*.sh cleanly.
+if command -v gh >/dev/null && gh auth status >/dev/null 2>&1; then
+  log "Clearing repo deploy state on $GITHUB_REPO..."
+  for var in DEPLOY_OWNER DEPLOY_MODE; do
+    gh variable delete "$var" -R "$GITHUB_REPO" >/dev/null 2>&1 || true
+  done
+  for secret in SSH_HOST SSH_HOST_NGINX SSH_HOST_BACKEND BACKEND_PRIVATE_IP SSH_USER SSH_PRIVATE_KEY; do
+    gh secret delete "$secret" -R "$GITHUB_REPO" >/dev/null 2>&1 || true
+  done
+  log "Cleared DEPLOY_OWNER, DEPLOY_MODE, and deploy secrets."
+else
+  log "gh CLI not available or not logged in — skipping GitHub cleanup."
+  log "Run this manually if needed so the next teammate can deploy:"
+  log "  gh variable delete DEPLOY_OWNER DEPLOY_MODE -R $GITHUB_REPO"
+fi

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -73,10 +73,16 @@ az network vnet create \
 
 create_vm() {
   local name="$1"
+  local public_ip_mode="${2:-with-public-ip}"
   log "Creating VM '$name'..."
   if az vm show -g "$RESOURCE_GROUP" -n "$name" >/dev/null 2>&1; then
     log "VM '$name' already exists, skipping create."
     return
+  fi
+  local pip_args=(--public-ip-sku Standard)
+  if [[ "$public_ip_mode" == "no-public-ip" ]]; then
+    # Empty string to --public-ip-address tells az vm create to skip the PIP.
+    pip_args=(--public-ip-address "")
   fi
   az vm create \
     --resource-group "$RESOURCE_GROUP" \
@@ -87,12 +93,12 @@ create_vm() {
     --ssh-key-values "$SSH_PUB_KEY_PATH" \
     --vnet-name "$VNET_NAME" \
     --subnet "$SUBNET_NAME" \
-    --public-ip-sku Standard \
+    "${pip_args[@]}" \
     --output none
 }
 
 create_vm "$NGINX_VM"
-create_vm "$BACKEND_VM"
+create_vm "$BACKEND_VM" "no-public-ip"
 
 # ---------- NSG rules ----------
 log "Opening ports 80 and 443 on '$NGINX_VM'..."
@@ -142,21 +148,22 @@ az network nsg rule update \
 # ---------- IP lookup ----------
 log "Fetching IP addresses..."
 NGINX_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$NGINX_VM"   --query publicIps  -o tsv)
-BACKEND_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$BACKEND_VM" --query publicIps  -o tsv)
 BACKEND_PRIVATE_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$BACKEND_VM" --query privateIps -o tsv)
 
 log "  nginx   public IP:  $NGINX_IP"
-log "  backend public IP:  $BACKEND_IP"
-log "  backend private IP: $BACKEND_PRIVATE_IP"
+log "  backend private IP: $BACKEND_PRIVATE_IP (no public IP — reachable only via nginx)"
 
 # ---------- Provision VMs over SSH ----------
 SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i "$SSH_KEY_PATH")
 
 wait_for_ssh() {
   local host="$1"
-  log "Waiting for SSH on $host..."
+  local jump_host="${2:-}"
+  local extra=()
+  [[ -n "$jump_host" ]] && extra=(-o "ProxyJump=$ADMIN_USER@$jump_host")
+  log "Waiting for SSH on $host${jump_host:+ (via $jump_host)}..."
   for _ in $(seq 1 30); do
-    if ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$host" 'true' 2>/dev/null; then
+    if ssh "${SSH_OPTS[@]}" "${extra[@]}" "$ADMIN_USER@$host" 'true' 2>/dev/null; then
       return 0
     fi
     sleep 5
@@ -165,10 +172,12 @@ wait_for_ssh() {
 }
 
 provision() {
-  local host="$1" label="$2"
-  wait_for_ssh "$host"
-  log "Provisioning $label ($host): base packages + Docker..."
-  ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$host" 'bash -s' <<'REMOTE'
+  local host="$1" label="$2" jump_host="${3:-}"
+  local extra=()
+  [[ -n "$jump_host" ]] && extra=(-o "ProxyJump=$ADMIN_USER@$jump_host")
+  wait_for_ssh "$host" "$jump_host"
+  log "Provisioning $label ($host)${jump_host:+ via $jump_host}: base packages + Docker..."
+  ssh "${SSH_OPTS[@]}" "${extra[@]}" "$ADMIN_USER@$host" 'bash -s' <<'REMOTE'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 sudo -E apt-get update -y
@@ -190,8 +199,8 @@ mkdir -p "$HOME/app"
 REMOTE
 }
 
-provision "$NGINX_IP"   "nginx VM"
-provision "$BACKEND_IP" "backend VM"
+provision "$NGINX_IP"          "nginx VM"
+provision "$BACKEND_PRIVATE_IP" "backend VM" "$NGINX_IP"
 
 # ---------- GitHub secrets ----------
 log "Setting GitHub secrets on $GITHUB_REPO..."
@@ -203,9 +212,12 @@ set_secret() {
 
 set_secret SSH_USER            "$ADMIN_USER"
 set_secret SSH_HOST_NGINX      "$NGINX_IP"
-set_secret SSH_HOST_BACKEND    "$BACKEND_IP"
 set_secret BACKEND_PRIVATE_IP  "$BACKEND_PRIVATE_IP"
 gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
+
+# Clean up a stale SSH_HOST_BACKEND from previous versions where the backend
+# was reachable on its own public IP. Ignore errors if the secret isn't there.
+gh secret delete SSH_HOST_BACKEND -R "$GITHUB_REPO" >/dev/null 2>&1 || true
 
 log "Setting deploy-mode variable to 'two-vms' on $GITHUB_REPO..."
 gh variable set DEPLOY_MODE --body "two-vms" -R "$GITHUB_REPO"
@@ -215,13 +227,11 @@ cat <<SUMMARY
 
 Two-VM deployment provisioned:
   Resource group:     $RESOURCE_GROUP
-  nginx VM:           $NGINX_IP   (ports 80/443 open)
-  backend VM:         $BACKEND_IP (port $BACKEND_PORT open from VNet only)
-  backend private IP: $BACKEND_PRIVATE_IP
+  nginx VM:           $NGINX_IP          (ports 80/443 open)
+  backend VM:         $BACKEND_PRIVATE_IP (no public IP; port $BACKEND_PORT from nginx only)
 
 GitHub secrets set on $GITHUB_REPO:
-  SSH_USER, SSH_HOST_NGINX, SSH_HOST_BACKEND,
-  BACKEND_PRIVATE_IP, SSH_PRIVATE_KEY
+  SSH_USER, SSH_HOST_NGINX, BACKEND_PRIVATE_IP, SSH_PRIVATE_KEY
 
 Push to master to trigger the deploy pipeline.
 SUMMARY

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -19,8 +19,6 @@ BACKEND_VM="${BACKEND_VM:-cookbook-backend}"
 VM_SIZE="${VM_SIZE:-Standard_B1s}"
 VM_IMAGE="Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
 ADMIN_USER="${ADMIN_USER:-azureuser}"
-SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-$HOME/.ssh/id_rsa.pub}"
-SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/id_rsa}"
 
 GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
 
@@ -32,8 +30,24 @@ die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 command -v az >/dev/null || die "Azure CLI (az) not installed."
 command -v gh >/dev/null || die "GitHub CLI (gh) not installed."
 command -v ssh >/dev/null || die "ssh not installed."
+
+# Auto-detect an SSH key pair if the user didn't set env vars.
+# Order matches Azure's recommendations and ssh-keygen defaults.
+if [[ -z "${SSH_KEY_PATH:-}" ]]; then
+  for candidate in id_rsa id_ed25519 id_ecdsa; do
+    if [[ -f "$HOME/.ssh/$candidate" && -f "$HOME/.ssh/$candidate.pub" ]]; then
+      SSH_KEY_PATH="$HOME/.ssh/$candidate"
+      SSH_PUB_KEY_PATH="$HOME/.ssh/$candidate.pub"
+      log "Using SSH key pair: $SSH_KEY_PATH"
+      break
+    fi
+  done
+fi
+SSH_KEY_PATH="${SSH_KEY_PATH:-}"
+SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-${SSH_KEY_PATH}.pub}"
+
+[[ -n "$SSH_KEY_PATH" && -f "$SSH_KEY_PATH" ]] || die "No SSH private key found. Tried ~/.ssh/{id_rsa,id_ed25519,id_ecdsa}. Generate one (ssh-keygen -t ed25519) or set SSH_KEY_PATH."
 [[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
-[[ -f "$SSH_KEY_PATH" ]] || die "SSH private key not found at $SSH_KEY_PATH"
 
 log "Verifying Azure login..."
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -52,10 +52,35 @@ SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-${SSH_KEY_PATH}.pub}"
 log "Verifying Azure login..."
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
 ACCOUNT_NAME=$(az account show --query name -o tsv)
-log "Azure account: $ACCOUNT_NAME"
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SIGNED_IN_USER=$(az account show --query user.name -o tsv)
 
 log "Verifying GitHub login..."
 gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+GH_USER=$(gh api user --jq .login)
+
+cat <<CONFIRM
+
+About to provision a two-VM deployment:
+
+  Azure subscription : $ACCOUNT_NAME
+  Subscription ID    : $SUBSCRIPTION_ID
+  Signed-in user     : $SIGNED_IN_USER
+  Resource group     : $RESOURCE_GROUP   (location: $LOCATION)
+  VNet / subnet      : $VNET_NAME ($VNET_CIDR) / $SUBNET_NAME ($SUBNET_CIDR)
+  VMs                : $NGINX_VM (public) + $BACKEND_VM (private, no public IP)
+  VM size            : $VM_SIZE, Ubuntu 22.04
+
+  GitHub repo        : $GITHUB_REPO
+  GitHub user        : $GH_USER
+  Secrets to be set  : SSH_HOST_NGINX, BACKEND_PRIVATE_IP, SSH_USER, SSH_PRIVATE_KEY
+  Variable to be set : DEPLOY_MODE=two-vms
+
+This will consume Azure credits and overwrite the repo's deploy secrets.
+CONFIRM
+
+read -rp "Continue? (y/N): " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || die "Aborted by user."
 
 # ---------- Resource group ----------
 log "Creating resource group '$RESOURCE_GROUP' in $LOCATION..."

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Provisions the two-VM cookbook deployment in Azure and wires up
 # GitHub repo secrets so the CI/CD pipeline can SSH into the VMs.
 #
-# Run interactively the first time:   bash infrastructure/azure-setup.sh
+# Run interactively the first time:   bash infrastructure/create_two_vms.sh
 # Safe to re-run: resource creation is idempotent; existing resources are reused.
 
 RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
@@ -85,7 +85,10 @@ log "Opening ports 80 and 443 on '$NGINX_VM'..."
 az vm open-port --resource-group "$RESOURCE_GROUP" --name "$NGINX_VM" --port 80  --priority 1001 --output none || true
 az vm open-port --resource-group "$RESOURCE_GROUP" --name "$NGINX_VM" --port 443 --priority 1002 --output none || true
 
-log "Allowing backend port $BACKEND_PORT from VNet ($VNET_CIDR) only on '$BACKEND_VM'..."
+NGINX_PRIVATE_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$NGINX_VM" --query privateIps -o tsv)
+[[ -n "$NGINX_PRIVATE_IP" ]] || die "Could not resolve nginx private IP"
+
+log "Allowing backend port $BACKEND_PORT from nginx ($NGINX_PRIVATE_IP) only on '$BACKEND_VM'..."
 BACKEND_NSG=$(az vm show -g "$RESOURCE_GROUP" -n "$BACKEND_VM" \
   --query "networkProfile.networkInterfaces[0].id" -o tsv \
   | xargs -I{} az network nic show --ids {} --query "networkSecurityGroup.id" -o tsv)
@@ -96,15 +99,31 @@ if [[ -z "$BACKEND_NSG" ]]; then
 fi
 [[ -n "$BACKEND_NSG" ]] || die "Could not locate NSG for $BACKEND_VM"
 
+BACKEND_NSG_NAME="$(basename "$BACKEND_NSG")"
+
+# If a prior run created a broader rule, drop it so we end up with the stricter one.
+az network nsg rule delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$BACKEND_NSG_NAME" \
+  --name "allow-backend-from-vnet" \
+  --output none 2>/dev/null || true
+
 az network nsg rule create \
   --resource-group "$RESOURCE_GROUP" \
-  --nsg-name "$(basename "$BACKEND_NSG")" \
-  --name "allow-backend-from-vnet" \
+  --nsg-name "$BACKEND_NSG_NAME" \
+  --name "allow-backend-from-nginx" \
   --priority 1100 \
-  --source-address-prefixes "$VNET_CIDR" \
+  --source-address-prefixes "$NGINX_PRIVATE_IP" \
   --destination-port-ranges "$BACKEND_PORT" \
   --access Allow --protocol Tcp --direction Inbound \
-  --output none 2>/dev/null || log "Rule 'allow-backend-from-vnet' already exists."
+  --output none 2>/dev/null || \
+az network nsg rule update \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$BACKEND_NSG_NAME" \
+  --name "allow-backend-from-nginx" \
+  --source-address-prefixes "$NGINX_PRIVATE_IP" \
+  --destination-port-ranges "$BACKEND_PORT" \
+  --output none
 
 # ---------- IP lookup ----------
 log "Fetching IP addresses..."
@@ -173,6 +192,9 @@ set_secret SSH_HOST_NGINX      "$NGINX_IP"
 set_secret SSH_HOST_BACKEND    "$BACKEND_IP"
 set_secret BACKEND_PRIVATE_IP  "$BACKEND_PRIVATE_IP"
 gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
+
+log "Setting deploy-mode variable to 'two-vms' on $GITHUB_REPO..."
+gh variable set DEPLOY_MODE --body "two-vms" -R "$GITHUB_REPO"
 
 log "Done."
 cat <<SUMMARY

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -59,6 +59,46 @@ log "Verifying GitHub login..."
 gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
 GH_USER=$(gh api user --jq .login)
 
+# ---------- Single-active-deployment guard ----------
+# The repo's deploy secrets and DEPLOY_MODE variable are shared team state.
+# Running this script overwrites them, which orphans any live deployment
+# pointed at by the old values (those VMs keep running in someone else's
+# Azure sub, burning credits, no longer receiving deploys). Track the
+# current owner in DEPLOY_OWNER; refuse if it's someone else unless FORCE=1.
+CURRENT_OWNER=$(gh variable list -R "$GITHUB_REPO" --json name,value \
+  -q '.[] | select(.name=="DEPLOY_OWNER") | .value' 2>/dev/null || true)
+CURRENT_MODE=$(gh variable list -R "$GITHUB_REPO" --json name,value \
+  -q '.[] | select(.name=="DEPLOY_MODE") | .value' 2>/dev/null || true)
+
+if [[ -n "$CURRENT_OWNER" && "$CURRENT_OWNER" != "$GH_USER" && "${FORCE:-0}" != "1" ]]; then
+  cat >&2 <<ERR
+
+[error] Another teammate already has an active deployment on this repo.
+
+  Current owner  : $CURRENT_OWNER
+  Deploy mode    : ${CURRENT_MODE:-unknown}
+  Repo           : $GITHUB_REPO
+
+Running this script now would overwrite the repo's deploy secrets and
+orphan $CURRENT_OWNER's VMs (still running in their Azure subscription,
+still burning credits, but no longer receiving deploys).
+
+What to do:
+  1. Ask $CURRENT_OWNER to run on their machine:
+       bash infrastructure/azure-teardown.sh
+     That deletes their Azure resources and clears the lock.
+  2. Or, if you know the lock is stale (VMs already gone), override:
+       FORCE=1 bash infrastructure/create_two_vms.sh
+
+ERR
+  exit 1
+fi
+
+if [[ -z "$CURRENT_OWNER" && -n "$CURRENT_MODE" ]]; then
+  log "Note: DEPLOY_MODE=$CURRENT_MODE is set but no DEPLOY_OWNER recorded."
+  log "      Claiming ownership. If a teammate still has VMs up, ask them to tear down."
+fi
+
 cat <<CONFIRM
 
 About to provision a two-VM deployment:
@@ -246,6 +286,9 @@ gh secret delete SSH_HOST_BACKEND -R "$GITHUB_REPO" >/dev/null 2>&1 || true
 
 log "Setting deploy-mode variable to 'two-vms' on $GITHUB_REPO..."
 gh variable set DEPLOY_MODE --body "two-vms" -R "$GITHUB_REPO"
+
+log "Claiming deployment ownership as '$GH_USER'..."
+gh variable set DEPLOY_OWNER --body "$GH_USER" -R "$GITHUB_REPO"
 
 log "Done."
 cat <<SUMMARY

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -14,8 +14,6 @@ VM_NAME="${VM_NAME:-cookbook-vm}"
 VM_SIZE="${VM_SIZE:-Standard_B1s}"
 VM_IMAGE="Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
 ADMIN_USER="${ADMIN_USER:-azureuser}"
-SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-$HOME/.ssh/id_rsa.pub}"
-SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/id_rsa}"
 
 GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
 
@@ -27,8 +25,24 @@ die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 command -v az >/dev/null || die "Azure CLI (az) not installed."
 command -v gh >/dev/null || die "GitHub CLI (gh) not installed."
 command -v ssh >/dev/null || die "ssh not installed."
+
+# Auto-detect an SSH key pair if the user didn't set env vars.
+# Order matches Azure's recommendations and ssh-keygen defaults.
+if [[ -z "${SSH_KEY_PATH:-}" ]]; then
+  for candidate in id_rsa id_ed25519 id_ecdsa; do
+    if [[ -f "$HOME/.ssh/$candidate" && -f "$HOME/.ssh/$candidate.pub" ]]; then
+      SSH_KEY_PATH="$HOME/.ssh/$candidate"
+      SSH_PUB_KEY_PATH="$HOME/.ssh/$candidate.pub"
+      log "Using SSH key pair: $SSH_KEY_PATH"
+      break
+    fi
+  done
+fi
+SSH_KEY_PATH="${SSH_KEY_PATH:-}"
+SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-${SSH_KEY_PATH}.pub}"
+
+[[ -n "$SSH_KEY_PATH" && -f "$SSH_KEY_PATH" ]] || die "No SSH private key found. Tried ~/.ssh/{id_rsa,id_ed25519,id_ecdsa}. Generate one (ssh-keygen -t ed25519) or set SSH_KEY_PATH."
 [[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
-[[ -f "$SSH_KEY_PATH" ]] || die "SSH private key not found at $SSH_KEY_PATH"
 
 log "Verifying Azure login..."
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -54,6 +54,46 @@ log "Verifying GitHub login..."
 gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
 GH_USER=$(gh api user --jq .login)
 
+# ---------- Single-active-deployment guard ----------
+# The repo's deploy secrets and DEPLOY_MODE variable are shared team state.
+# Running this script overwrites them, which orphans any live deployment
+# pointed at by the old values (those VMs keep running in someone else's
+# Azure sub, burning credits, no longer receiving deploys). Track the
+# current owner in DEPLOY_OWNER; refuse if it's someone else unless FORCE=1.
+CURRENT_OWNER=$(gh variable list -R "$GITHUB_REPO" --json name,value \
+  -q '.[] | select(.name=="DEPLOY_OWNER") | .value' 2>/dev/null || true)
+CURRENT_MODE=$(gh variable list -R "$GITHUB_REPO" --json name,value \
+  -q '.[] | select(.name=="DEPLOY_MODE") | .value' 2>/dev/null || true)
+
+if [[ -n "$CURRENT_OWNER" && "$CURRENT_OWNER" != "$GH_USER" && "${FORCE:-0}" != "1" ]]; then
+  cat >&2 <<ERR
+
+[error] Another teammate already has an active deployment on this repo.
+
+  Current owner  : $CURRENT_OWNER
+  Deploy mode    : ${CURRENT_MODE:-unknown}
+  Repo           : $GITHUB_REPO
+
+Running this script now would overwrite the repo's deploy secrets and
+orphan $CURRENT_OWNER's VMs (still running in their Azure subscription,
+still burning credits, but no longer receiving deploys).
+
+What to do:
+  1. Ask $CURRENT_OWNER to run on their machine:
+       bash infrastructure/azure-teardown.sh
+     That deletes their Azure resources and clears the lock.
+  2. Or, if you know the lock is stale (VMs already gone), override:
+       FORCE=1 bash infrastructure/create_vm.sh
+
+ERR
+  exit 1
+fi
+
+if [[ -z "$CURRENT_OWNER" && -n "$CURRENT_MODE" ]]; then
+  log "Note: DEPLOY_MODE=$CURRENT_MODE is set but no DEPLOY_OWNER recorded."
+  log "      Claiming ownership. If a teammate still has VMs up, ask them to tear down."
+fi
+
 cat <<CONFIRM
 
 About to provision a single-VM deployment:
@@ -158,6 +198,9 @@ gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
 
 log "Setting deploy-mode variable to 'single' on $GITHUB_REPO..."
 gh variable set DEPLOY_MODE --body "single" -R "$GITHUB_REPO"
+
+log "Claiming deployment ownership as '$GH_USER'..."
+gh variable set DEPLOY_OWNER --body "$GH_USER" -R "$GITHUB_REPO"
 
 log "Done."
 cat <<SUMMARY

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -47,10 +47,33 @@ SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-${SSH_KEY_PATH}.pub}"
 log "Verifying Azure login..."
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
 ACCOUNT_NAME=$(az account show --query name -o tsv)
-log "Azure account: $ACCOUNT_NAME"
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SIGNED_IN_USER=$(az account show --query user.name -o tsv)
 
 log "Verifying GitHub login..."
 gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+GH_USER=$(gh api user --jq .login)
+
+cat <<CONFIRM
+
+About to provision a single-VM deployment:
+
+  Azure subscription : $ACCOUNT_NAME
+  Subscription ID    : $SUBSCRIPTION_ID
+  Signed-in user     : $SIGNED_IN_USER
+  Resource group     : $RESOURCE_GROUP   (location: $LOCATION)
+  VM                 : $VM_NAME ($VM_SIZE, Ubuntu 22.04)
+
+  GitHub repo        : $GITHUB_REPO
+  GitHub user        : $GH_USER
+  Secrets to be set  : SSH_HOST, SSH_USER, SSH_PRIVATE_KEY
+  Variable to be set : DEPLOY_MODE=single
+
+This will consume Azure credits and overwrite the repo's deploy secrets.
+CONFIRM
+
+read -rp "Continue? (y/N): " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || die "Aborted by user."
 
 # ---------- Resource group ----------
 log "Creating resource group '$RESOURCE_GROUP' in $LOCATION..."

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provisions the single-VM cookbook deployment in Azure and wires up
+# GitHub repo secrets so the CI/CD pipeline can SSH into the VM.
+#
+# Run interactively the first time:   bash infrastructure/create_vm.sh
+# Safe to re-run: resource creation is idempotent; existing resources are reused.
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
+LOCATION="${LOCATION:-francecentral}"
+
+VM_NAME="${VM_NAME:-cookbook-vm}"
+VM_SIZE="${VM_SIZE:-Standard_B1s}"
+VM_IMAGE="Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest"
+ADMIN_USER="${ADMIN_USER:-azureuser}"
+SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-$HOME/.ssh/id_rsa.pub}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/id_rsa}"
+
+GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
+
+APP_PORT=3000
+
+log() { printf '\n\033[1;34m[setup]\033[0m %s\n' "$*"; }
+die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v az >/dev/null || die "Azure CLI (az) not installed."
+command -v gh >/dev/null || die "GitHub CLI (gh) not installed."
+command -v ssh >/dev/null || die "ssh not installed."
+[[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
+[[ -f "$SSH_KEY_PATH" ]] || die "SSH private key not found at $SSH_KEY_PATH"
+
+log "Verifying Azure login..."
+az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+ACCOUNT_NAME=$(az account show --query name -o tsv)
+log "Azure account: $ACCOUNT_NAME"
+
+log "Verifying GitHub login..."
+gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+
+# ---------- Resource group ----------
+log "Creating resource group '$RESOURCE_GROUP' in $LOCATION..."
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION" --output none
+
+# ---------- VM ----------
+log "Creating VM '$VM_NAME'..."
+if az vm show -g "$RESOURCE_GROUP" -n "$VM_NAME" >/dev/null 2>&1; then
+  log "VM '$VM_NAME' already exists, skipping create."
+else
+  az vm create \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$VM_NAME" \
+    --image "$VM_IMAGE" \
+    --size "$VM_SIZE" \
+    --admin-username "$ADMIN_USER" \
+    --ssh-key-values "$SSH_PUB_KEY_PATH" \
+    --public-ip-sku Standard \
+    --output none
+fi
+
+# ---------- NSG rules ----------
+log "Opening ports 80, 443, and $APP_PORT on '$VM_NAME'..."
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 80        --priority 1001 --output none || true
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 443       --priority 1002 --output none || true
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port "$APP_PORT" --priority 1003 --output none || true
+
+# ---------- IP lookup ----------
+log "Fetching IP address..."
+VM_IP=$(az vm show -d -g "$RESOURCE_GROUP" -n "$VM_NAME" --query publicIps -o tsv)
+log "  VM public IP: $VM_IP"
+
+# ---------- Provision VM over SSH ----------
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i "$SSH_KEY_PATH")
+
+wait_for_ssh() {
+  local host="$1"
+  log "Waiting for SSH on $host..."
+  for _ in $(seq 1 30); do
+    if ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$host" 'true' 2>/dev/null; then
+      return 0
+    fi
+    sleep 5
+  done
+  die "SSH never came up on $host"
+}
+
+wait_for_ssh "$VM_IP"
+log "Provisioning VM ($VM_IP): base packages + Docker..."
+ssh "${SSH_OPTS[@]}" "$ADMIN_USER@$VM_IP" 'bash -s' <<'REMOTE'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+sudo -E apt-get update -y
+sudo -E apt-get upgrade -y
+sudo -E apt-get install -y curl wget git unzip ca-certificates gnupg lsb-release
+
+if ! command -v docker >/dev/null 2>&1; then
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo -E apt-get update -y
+  sudo -E apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo usermod -aG docker "$USER"
+fi
+sudo systemctl enable --now docker
+mkdir -p "$HOME/app"
+REMOTE
+
+# ---------- GitHub secrets ----------
+log "Setting GitHub secrets on $GITHUB_REPO..."
+set_secret() {
+  # NB: `--body -` would literally store the string "-"; omit --body so gh
+  # reads the value from stdin instead.
+  printf '%s' "$2" | gh secret set "$1" -R "$GITHUB_REPO"
+}
+
+set_secret SSH_USER "$ADMIN_USER"
+set_secret SSH_HOST "$VM_IP"
+gh secret set SSH_PRIVATE_KEY -R "$GITHUB_REPO" < "$SSH_KEY_PATH"
+
+log "Setting deploy-mode variable to 'single' on $GITHUB_REPO..."
+gh variable set DEPLOY_MODE --body "single" -R "$GITHUB_REPO"
+
+log "Done."
+cat <<SUMMARY
+
+Single-VM deployment provisioned:
+  Resource group: $RESOURCE_GROUP
+  VM:             $VM_NAME ($VM_IP)
+  Open ports:     80, 443, $APP_PORT
+
+GitHub secrets set on $GITHUB_REPO:
+  SSH_USER, SSH_HOST, SSH_PRIVATE_KEY
+
+Push to master to trigger the deploy pipeline.
+SUMMARY

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,8 +10,6 @@ info:
 servers:
   - url: http://localhost:3000
     description: Local development server
-  - url: http://172.189.59.40
-    description: Production server (Azure VM)
 
 tags:
   - name: Health

--- a/scripts/security-check.sh
+++ b/scripts/security-check.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Pre-push security gate for the cookbook repo.
+# Runs: (1) forbidden-file check, (2) secret scan, (3) npm audit in backend + frontend.
+# Exit non-zero on any failure. Do NOT bypass with --no-verify.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "ERROR: must be run inside the git repo." >&2
+  exit 2
+}
+cd "$REPO_ROOT"
+
+FAIL=0
+SELF_PATH="scripts/security-check.sh"
+
+section() { printf '\n=== %s ===\n' "$1"; }
+pass()    { printf '  OK   %s\n' "$1"; }
+fail()    { printf '  FAIL %s\n' "$1"; FAIL=1; }
+
+# ---------------------------------------------------------------------------
+# 1. Forbidden-file check
+# ---------------------------------------------------------------------------
+section "Forbidden file check"
+
+FORBIDDEN_REGEX='(^|/)(\.env(\..+)?|.+\.db|.+\.pem)$|(^|/)(node_modules|dist)(/|$)'
+
+# Tracked files (what's actually pushed) + currently staged files.
+TRACKED=$(git ls-files)
+STAGED=$(git diff --cached --name-only)
+
+OFFENDERS=$(printf '%s\n%s\n' "$TRACKED" "$STAGED" \
+  | sort -u \
+  | grep -E "$FORBIDDEN_REGEX" || true)
+
+# Allow .env.example / .env.sample explicitly.
+OFFENDERS=$(printf '%s\n' "$OFFENDERS" \
+  | grep -vE '(^|/)\.env\.(example|sample|template)$' || true)
+
+if [ -n "$OFFENDERS" ]; then
+  fail "forbidden files tracked or staged:"
+  printf '%s\n' "$OFFENDERS" | sed 's/^/       - /'
+else
+  pass "no forbidden files (.env, *.db, *.pem, node_modules/, dist/)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Secret scan
+# ---------------------------------------------------------------------------
+section "Secret scan"
+
+# Patterns for common credentials. Deliberately conservative to limit false
+# positives. Extend as needed.
+PATTERNS=(
+  'AKIA[0-9A-Z]{16}'                                 # AWS access key id
+  '-----BEGIN ((RSA|DSA|EC|OPENSSH|PGP) )?PRIVATE KEY-----'  # private keys
+  'ghp_[A-Za-z0-9]{36}'                              # GitHub PAT (classic)
+  'github_pat_[A-Za-z0-9_]{82}'                      # GitHub PAT (fine-grained)
+  'gh[osu]_[A-Za-z0-9]{36}'                          # GitHub OAuth/server/user tokens
+  'xox[baprs]-[A-Za-z0-9-]{10,}'                     # Slack tokens
+  'sk-[A-Za-z0-9]{32,}'                              # OpenAI / Anthropic-style keys
+  'AIza[0-9A-Za-z_-]{35}'                            # Google API keys
+)
+
+# Build a single alternation for grep -E.
+JOINED_PATTERN=$(IFS='|'; echo "${PATTERNS[*]}")
+
+# Scan tracked text files only. Exclude this script (contains the patterns
+# above) and the node_modules/dist folders (already banned, but cheap guard).
+MATCHES=$(git ls-files -z \
+  | grep -zvE "^($SELF_PATH|.*node_modules/.*|.*dist/.*)$" \
+  | xargs -0 grep -InE "$JOINED_PATTERN" 2>/dev/null || true)
+
+if [ -n "$MATCHES" ]; then
+  fail "possible secrets detected:"
+  printf '%s\n' "$MATCHES" | sed 's/^/       /'
+else
+  pass "no known secret patterns found in tracked files"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. npm audit (backend + frontend)
+# ---------------------------------------------------------------------------
+run_audit() {
+  local dir="$1"
+  if [ ! -f "$dir/package.json" ]; then
+    pass "$dir: no package.json, skipping"
+    return
+  fi
+  if [ ! -f "$dir/package-lock.json" ]; then
+    fail "$dir: missing package-lock.json (npm audit needs it)"
+    return
+  fi
+  ( cd "$dir" && npm audit --audit-level=high --omit=dev >/tmp/audit.$$ 2>&1 )
+  local rc=$?
+  if [ $rc -eq 0 ]; then
+    pass "$dir: npm audit clean at level=high"
+  else
+    fail "$dir: npm audit found vulnerabilities at level=high"
+    sed 's/^/       /' /tmp/audit.$$
+  fi
+  rm -f /tmp/audit.$$
+}
+
+section "npm audit: backend"
+run_audit backend
+
+section "npm audit: frontend"
+run_audit frontend
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+if [ $FAIL -ne 0 ]; then
+  echo "Security check FAILED. Fix the issues above before pushing."
+  exit 1
+fi
+echo "Security check PASSED."
+exit 0


### PR DESCRIPTION
Bundles the work needed to satisfy the assignment's infrastructure checklist, harden the two-VM topology, make scripts safe for a team to share, and add AI-agent guardrails to the repo.

## 1. Infrastructure — deploy pipeline + topologies
- `infrastructure/create_vm.sh` — Part 1 single-VM setup (opens 80/443/3000, installs Docker, wires `SSH_HOST` + `SSH_PRIVATE_KEY` secrets, sets `DEPLOY_MODE=single`).
- `infrastructure/create_two_vms.sh` — Part 2 two-VM setup (VNet + nginx + backend, NSG locks backend port 3000 to nginx's private IP, sets `DEPLOY_MODE=two-vms`). Renamed from `azure-setup.sh` to match the checklist.
- `docker-compose.single-vm.yml` + `ci-cd.yml` gates deploy jobs on `vars.DEPLOY_MODE`, so either topology deploys without workflow edits.
- `infrastructure/README.md` covers prereqs / both topologies / teardown / mode switching.
- Root `README.md` rewritten: drops stale GHCR_PAT docs, points at `infrastructure/README.md`, fixes local dev to use `docker compose --profile dev`.

## 2. Infrastructure — backend hardening
- Backend VM now has **no public IP** at all — only a private VNet address. Removes SSH-from-internet exposure the checklist flagged.
- Provisioning (`create_two_vms.sh`) reaches the backend via **nginx as an SSH jump host** (`ProxyJump`).
- `deploy-backend` job in `ci-cd.yml` uses the same jump-host pattern (`-o ProxyJump=$SSH_USER@$SSH_HOST_NGINX`) to reach `BACKEND_PRIVATE_IP`. `SSH_HOST_BACKEND` secret is retired.

## 3. Infrastructure — team-safe ergonomics
- **SSH key auto-detect** (`id_rsa` → `id_ed25519` → `id_ecdsa`, first match wins). Addresses the checklist "no changes to scripts between runs" rule — teammates with modern keypairs don't have to set env vars.
- **Account + plan confirmation prompt** before any `az create` or `az group delete`. Prints Azure subscription name + ID, signed-in user, target RG, GitHub repo/user, secrets/vars about to change — then asks `(y/N)`. Stops accidental deploys into the wrong subscription.
- **Single-active-deployment lock** via `DEPLOY_OWNER` repo variable. The create scripts refuse to run if another teammate already owns the current deployment; teardown clears the lock along with `DEPLOY_MODE` and the deploy secrets. `FORCE=1` override for stale-lock recovery.

## 4. AI agent guardrails + pre-push security check
- `AGENTS.md` — canonical rules for any AI coding agent (read-order, git flow, security gate, forbidden-file list, do-not-touch paths).
- `CLAUDE.md` + `.github/copilot-instructions.md` — tool-specific pointers at `AGENTS.md`.
- `scripts/security-check.sh` — pre-push gate: forbidden-file check (`.env`, `*.db`, `*.pem`, `node_modules/`, `dist/`), secret scan (AWS, private keys, GitHub PATs, Slack, OpenAI, Google), `npm audit --audit-level=high` in `backend/` and `frontend/`.
- Install locally (each clone, one-time): `cp scripts/security-check.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push`

## Checklist status (infra)
- [x] `infrastructure/create_vm.sh` (Part 1)
- [x] `infrastructure/create_two_vms.sh` (Part 2)
- [x] `infrastructure/azure-teardown.sh`
- [x] `infrastructure/README.md` covering prereqs / setup / teardown
- [x] Backend VM not directly reachable from the internet (no public IP)
- [x] Scripts work for any teammate without per-machine edits (SSH auto-detect)
- [x] Shared-state collisions between teammates are prevented (DEPLOY_OWNER lock)
- [ ] Full-cycle test (each member runs setup → deploy → teardown) — requires humans

## Deploy impact
Merging auto-deploys via `ci-cd.yml` to whichever VMs `DEPLOY_OWNER` currently points at. Safe to merge with no Azure RG running — the deploy job will just fail noisily; no infra is touched by the PR itself.

## Test plan
- [ ] CI green on this PR (`Security Audit`, backend/frontend Docker builds)
- [ ] `bash scripts/security-check.sh` passes locally
- [ ] Pre-push hook installed in at least one clone and verified to run
- [ ] Member A: `bash infrastructure/create_vm.sh` → push → app live at VM IP → `bash infrastructure/azure-teardown.sh`
- [ ] Member B: same flow (lock should refuse until A tears down)
- [ ] Member C: same flow
- [ ] Two-VM mode: app reachable at nginx public IP; backend port 3000 not reachable externally; no public IP on backend at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)