### PR TITLE
refactor: extract recipe service + frontend api wrapper

### DIFF
--- a/backend/routes/recipes.js
+++ b/backend/routes/recipes.js
@@ -1,245 +1,60 @@
 import { Router } from "express";
-import { db } from "../db.js";
+import * as recipes from "../services/recipes.js";
 
 const router = Router();
 
-// ── Helpers ──────────────────────────────────────────────
-
-async function upsertIngredient(name) {
-  let row = await db.prepare(`SELECT id FROM ingredients WHERE name = ?`).get(name);
-  if (!row) {
-    row = { id: (await db.prepare(`INSERT INTO ingredients (name) VALUES (?)`).run(name)).lastInsertRowid };
-  }
-  return row.id;
-}
-
-async function upsertTag(name) {
-  let row = await db.prepare(`SELECT id FROM tags WHERE name = ?`).get(name);
-  if (!row) {
-    row = { id: (await db.prepare(`INSERT INTO tags (name) VALUES (?)`).run(name)).lastInsertRowid };
-  }
-  return row.id;
-}
-
-async function saveIngredients(recipeId, ingredients = []) {
-  for (const ing of ingredients) {
-    if (!ing.name?.trim()) continue;
-    const ingredientId = await upsertIngredient(ing.name);
-    await db.prepare(`INSERT INTO recipe_ingredients (recipe_id, ingredient_id, amount, unit) VALUES (?, ?, ?, ?)`)
-      .run(recipeId, ingredientId, ing.amount || null, ing.unit || null);
-  }
-}
-
-async function saveTags(recipeId, tags = []) {
-  for (const t of tags) {
-    if (!t.name?.trim()) continue;
-    const tagId = await upsertTag(t.name);
-    await db.prepare(`INSERT INTO recipe_tags (recipe_id, tag_id) VALUES (?, ?)`).run(recipeId, tagId);
-  }
-}
-
-// ── GET alle opskrifter ──────────────────────────────────
 router.get("/recipes/", async (req, res) => {
   try {
-    const recipes = await db.prepare(
-      `SELECT id, title, time_minutes, price, link, image FROM recipes`
-    ).all();
-
-    // Fetch all ingredients and tags in 2 queries instead of 2×N
-    const allIngredients = await db.prepare(`
-      SELECT ri.recipe_id, i.id, i.name, ri.amount, ri.unit
-      FROM ingredients i
-      JOIN recipe_ingredients ri ON i.id = ri.ingredient_id
-    `).all();
-
-    const allTags = await db.prepare(`
-      SELECT rt.recipe_id, t.id, t.name
-      FROM tags t
-      JOIN recipe_tags rt ON t.id = rt.tag_id
-    `).all();
-
-    // Group by recipe_id for O(1) lookup
-    const ingredientsByRecipe = allIngredients.reduce((acc, i) => {
-      (acc[i.recipe_id] ??= []).push({ id: i.id, name: i.name, amount: i.amount, unit: i.unit });
-      return acc;
-    }, {});
-
-    const tagsByRecipe = allTags.reduce((acc, t) => {
-      (acc[t.recipe_id] ??= []).push({ id: t.id, name: t.name });
-      return acc;
-    }, {});
-
-    const result = recipes.map(r => ({
-      id: r.id,
-      title: r.title,
-      time_minutes: r.time_minutes,
-      price: r.price,
-      link: r.link || "",
-      image: r.image || null,
-      ingredients: ingredientsByRecipe[r.id] || [],
-      tags: tagsByRecipe[r.id] || [],
-    }));
-
-    res.status(200).json(result);
+    res.status(200).json(await recipes.listRecipes());
   } catch (err) {
     console.error("GET /recipes error:", err);
     res.status(500).json({ error: "Kunne ikke hente opskrifter." });
   }
 });
 
-// ── POST opret opskrift ──────────────────────────────────
 router.post("/recipes/", async (req, res) => {
   try {
     const data = req.body || {};
-
     if (!data.title?.trim()) {
       return res.status(400).json({ error: "Opskriften skal have et navn." });
     }
-
-    const recipe = await db.prepare(
-      `INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      data.title.trim(),
-      data.time_minutes || 0,
-      data.price || "0",
-      data.link || "",
-      data.description || "",
-      data.instructions?.length ? JSON.stringify(data.instructions) : null,
-      data.image || null,
-      data.country || null
-    );
-
-    const recipeId = recipe.lastInsertRowid;
-
-    await saveIngredients(recipeId, data.ingredients);
-    await saveTags(recipeId, data.tags);
-
-    res.status(201).json({ id: recipeId, ...data });
+    const id = await recipes.createRecipe(data);
+    res.status(201).json({ id, ...data });
   } catch (err) {
     console.error("POST /recipes error:", err);
     res.status(500).json({ error: "Kunne ikke oprette opskriften." });
   }
 });
 
-// ── GET opskrifter efter land ────────────────────────────
 router.get("/recipes/country/:country", async (req, res) => {
   try {
-    const country = req.params.country.toLowerCase();
-    const recipes = await db.prepare(
-      `SELECT id, title, time_minutes, price, link, description, image, country FROM recipes WHERE LOWER(country) = ?`
-    ).all(country);
-
-    const ids = recipes.map(r => r.id);
-    if (ids.length === 0) return res.status(200).json([]);
-
-    const placeholders = ids.map(() => "?").join(",");
-    const allTags = await db.prepare(`
-      SELECT rt.recipe_id, t.id, t.name
-      FROM tags t
-      JOIN recipe_tags rt ON t.id = rt.tag_id
-      WHERE rt.recipe_id IN (${placeholders})
-    `).all(...ids);
-
-    const tagsByRecipe = allTags.reduce((acc, t) => {
-      (acc[t.recipe_id] ??= []).push({ id: t.id, name: t.name });
-      return acc;
-    }, {});
-
-    const result = recipes.map(r => ({
-      id: r.id,
-      title: r.title,
-      time_minutes: r.time_minutes,
-      price: r.price,
-      link: r.link || "",
-      description: r.description || "",
-      image: r.image || null,
-      country: r.country,
-      tags: tagsByRecipe[r.id] || [],
-    }));
-
-    res.status(200).json(result);
+    res.status(200).json(await recipes.listRecipesByCountry(req.params.country));
   } catch (err) {
     console.error("GET /recipes/country error:", err);
     res.status(500).json({ error: "Kunne ikke hente opskrifter for dette land." });
   }
 });
 
-// ── GET enkelt opskrift ──────────────────────────────────
 router.get("/recipes/:id/", async (req, res) => {
   try {
-    const id = Number(req.params.id);
-    const recipe = await db.prepare(
-      `SELECT id, title, time_minutes, price, link, description, instructions, image FROM recipes WHERE id = ?`
-    ).get(id);
-
+    const recipe = await recipes.getRecipe(Number(req.params.id));
     if (!recipe) return res.status(404).json({ detail: "Not found" });
-
-    const ingredients = await db.prepare(`
-      SELECT i.id, i.name, ri.amount, ri.unit
-      FROM ingredients i
-      JOIN recipe_ingredients ri ON i.id = ri.ingredient_id
-      WHERE ri.recipe_id = ?
-    `).all(id);
-
-    const tags = await db.prepare(`
-      SELECT t.id, t.name
-      FROM tags t
-      JOIN recipe_tags rt ON t.id = rt.tag_id
-      WHERE rt.recipe_id = ?
-    `).all(id);
-
-    res.status(200).json({
-      id: recipe.id,
-      title: recipe.title,
-      time_minutes: recipe.time_minutes,
-      price: recipe.price,
-      link: recipe.link || "",
-      description: recipe.description || "",
-      instructions: recipe.instructions ? JSON.parse(recipe.instructions) : [],
-      image: recipe.image || null,
-      ingredients: ingredients.map(i => ({ id: i.id, name: i.name, amount: i.amount, unit: i.unit })),
-      tags: tags.map(t => ({ id: t.id, name: t.name })),
-    });
+    res.status(200).json(recipe);
   } catch (err) {
     console.error("GET /recipes/:id error:", err);
     res.status(500).json({ error: "Kunne ikke hente opskriften." });
   }
 });
 
-// ── PUT opdater opskrift ─────────────────────────────────
 router.put("/recipes/:id/", async (req, res) => {
   try {
     const id = Number(req.params.id);
     const data = req.body || {};
-
     if (!data.title?.trim()) {
       return res.status(400).json({ error: "Opskriften skal have et navn." });
     }
-
-    const existing = await db.prepare(`SELECT id FROM recipes WHERE id = ?`).get(id);
-    if (!existing) return res.status(404).json({ detail: "Not found" });
-
-    await db.prepare(
-      `UPDATE recipes SET title = ?, time_minutes = ?, price = ?, link = ?, description = ?, instructions = ?, image = ?, country = ? WHERE id = ?`
-    ).run(
-      data.title.trim(),
-      data.time_minutes || 0,
-      data.price || "0",
-      data.link || "",
-      data.description || "",
-      data.instructions?.length ? JSON.stringify(data.instructions) : null,
-      data.image || null,
-      data.country || null,
-      id
-    );
-
-    // Replace ingredients and tags
-    await db.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
-    await db.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
-
-    await saveIngredients(id, data.ingredients);
-    await saveTags(id, data.tags);
-
+    const ok = await recipes.updateRecipe(id, data);
+    if (!ok) return res.status(404).json({ detail: "Not found" });
     res.status(200).json({ id, ...data });
   } catch (err) {
     console.error("PUT /recipes/:id error:", err);
@@ -247,13 +62,9 @@ router.put("/recipes/:id/", async (req, res) => {
   }
 });
 
-// ── DELETE slet opskrift ─────────────────────────────────
 router.delete("/recipes/:id/", async (req, res) => {
   try {
-    const id = Number(req.params.id);
-    await db.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
-    await db.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
-    await db.prepare(`DELETE FROM recipes WHERE id = ?`).run(id);
+    await recipes.deleteRecipe(Number(req.params.id));
     res.status(204).send("");
   } catch (err) {
     console.error("DELETE /recipes/:id error:", err);
@@ -261,11 +72,9 @@ router.delete("/recipes/:id/", async (req, res) => {
   }
 });
 
-// ── Ingredients + Tags (read-only) ───────────────────────
 router.get("/ingredients/", async (req, res) => {
   try {
-    const ingredients = await db.prepare(`SELECT id, name FROM ingredients`).all();
-    res.status(200).json(ingredients);
+    res.status(200).json(await recipes.listIngredients());
   } catch (err) {
     console.error("GET /ingredients error:", err);
     res.status(500).json({ error: "Kunne ikke hente ingredienser." });
@@ -274,8 +83,7 @@ router.get("/ingredients/", async (req, res) => {
 
 router.get("/tags/", async (req, res) => {
   try {
-    const tags = await db.prepare(`SELECT id, name FROM tags`).all();
-    res.status(200).json(tags);
+    res.status(200).json(await recipes.listTags());
   } catch (err) {
     console.error("GET /tags error:", err);
     res.status(500).json({ error: "Kunne ikke hente tags." });

--- a/backend/services/recipes.js
+++ b/backend/services/recipes.js
@@ -1,0 +1,201 @@
+import { db } from "../db.js";
+
+async function upsertIngredient(name) {
+  let row = await db.prepare(`SELECT id FROM ingredients WHERE name = ?`).get(name);
+  if (!row) {
+    row = { id: (await db.prepare(`INSERT INTO ingredients (name) VALUES (?)`).run(name)).lastInsertRowid };
+  }
+  return row.id;
+}
+
+async function upsertTag(name) {
+  let row = await db.prepare(`SELECT id FROM tags WHERE name = ?`).get(name);
+  if (!row) {
+    row = { id: (await db.prepare(`INSERT INTO tags (name) VALUES (?)`).run(name)).lastInsertRowid };
+  }
+  return row.id;
+}
+
+async function saveIngredients(recipeId, ingredients = []) {
+  for (const ing of ingredients) {
+    if (!ing.name?.trim()) continue;
+    const ingredientId = await upsertIngredient(ing.name);
+    await db.prepare(`INSERT INTO recipe_ingredients (recipe_id, ingredient_id, amount, unit) VALUES (?, ?, ?, ?)`)
+      .run(recipeId, ingredientId, ing.amount || null, ing.unit || null);
+  }
+}
+
+async function saveTags(recipeId, tags = []) {
+  for (const t of tags) {
+    if (!t.name?.trim()) continue;
+    const tagId = await upsertTag(t.name);
+    await db.prepare(`INSERT INTO recipe_tags (recipe_id, tag_id) VALUES (?, ?)`).run(recipeId, tagId);
+  }
+}
+
+export async function listRecipes() {
+  const recipes = await db.prepare(
+    `SELECT id, title, time_minutes, price, link, image FROM recipes`
+  ).all();
+
+  const allIngredients = await db.prepare(`
+    SELECT ri.recipe_id, i.id, i.name, ri.amount, ri.unit
+    FROM ingredients i
+    JOIN recipe_ingredients ri ON i.id = ri.ingredient_id
+  `).all();
+
+  const allTags = await db.prepare(`
+    SELECT rt.recipe_id, t.id, t.name
+    FROM tags t
+    JOIN recipe_tags rt ON t.id = rt.tag_id
+  `).all();
+
+  const ingredientsByRecipe = allIngredients.reduce((acc, i) => {
+    (acc[i.recipe_id] ??= []).push({ id: i.id, name: i.name, amount: i.amount, unit: i.unit });
+    return acc;
+  }, {});
+
+  const tagsByRecipe = allTags.reduce((acc, t) => {
+    (acc[t.recipe_id] ??= []).push({ id: t.id, name: t.name });
+    return acc;
+  }, {});
+
+  return recipes.map(r => ({
+    id: r.id,
+    title: r.title,
+    time_minutes: r.time_minutes,
+    price: r.price,
+    link: r.link || "",
+    image: r.image || null,
+    ingredients: ingredientsByRecipe[r.id] || [],
+    tags: tagsByRecipe[r.id] || [],
+  }));
+}
+
+export async function listRecipesByCountry(country) {
+  const recipes = await db.prepare(
+    `SELECT id, title, time_minutes, price, link, description, image, country FROM recipes WHERE LOWER(country) = ?`
+  ).all(country.toLowerCase());
+
+  const ids = recipes.map(r => r.id);
+  if (ids.length === 0) return [];
+
+  const placeholders = ids.map(() => "?").join(",");
+  const allTags = await db.prepare(`
+    SELECT rt.recipe_id, t.id, t.name
+    FROM tags t
+    JOIN recipe_tags rt ON t.id = rt.tag_id
+    WHERE rt.recipe_id IN (${placeholders})
+  `).all(...ids);
+
+  const tagsByRecipe = allTags.reduce((acc, t) => {
+    (acc[t.recipe_id] ??= []).push({ id: t.id, name: t.name });
+    return acc;
+  }, {});
+
+  return recipes.map(r => ({
+    id: r.id,
+    title: r.title,
+    time_minutes: r.time_minutes,
+    price: r.price,
+    link: r.link || "",
+    description: r.description || "",
+    image: r.image || null,
+    country: r.country,
+    tags: tagsByRecipe[r.id] || [],
+  }));
+}
+
+export async function getRecipe(id) {
+  const recipe = await db.prepare(
+    `SELECT id, title, time_minutes, price, link, description, instructions, image FROM recipes WHERE id = ?`
+  ).get(id);
+
+  if (!recipe) return null;
+
+  const ingredients = await db.prepare(`
+    SELECT i.id, i.name, ri.amount, ri.unit
+    FROM ingredients i
+    JOIN recipe_ingredients ri ON i.id = ri.ingredient_id
+    WHERE ri.recipe_id = ?
+  `).all(id);
+
+  const tags = await db.prepare(`
+    SELECT t.id, t.name
+    FROM tags t
+    JOIN recipe_tags rt ON t.id = rt.tag_id
+    WHERE rt.recipe_id = ?
+  `).all(id);
+
+  return {
+    id: recipe.id,
+    title: recipe.title,
+    time_minutes: recipe.time_minutes,
+    price: recipe.price,
+    link: recipe.link || "",
+    description: recipe.description || "",
+    instructions: recipe.instructions ? JSON.parse(recipe.instructions) : [],
+    image: recipe.image || null,
+    ingredients: ingredients.map(i => ({ id: i.id, name: i.name, amount: i.amount, unit: i.unit })),
+    tags: tags.map(t => ({ id: t.id, name: t.name })),
+  };
+}
+
+export async function createRecipe(data) {
+  const result = await db.prepare(
+    `INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    data.title.trim(),
+    data.time_minutes || 0,
+    data.price || "0",
+    data.link || "",
+    data.description || "",
+    data.instructions?.length ? JSON.stringify(data.instructions) : null,
+    data.image || null,
+    data.country || null
+  );
+
+  const recipeId = result.lastInsertRowid;
+  await saveIngredients(recipeId, data.ingredients);
+  await saveTags(recipeId, data.tags);
+  return recipeId;
+}
+
+export async function updateRecipe(id, data) {
+  const existing = await db.prepare(`SELECT id FROM recipes WHERE id = ?`).get(id);
+  if (!existing) return false;
+
+  await db.prepare(
+    `UPDATE recipes SET title = ?, time_minutes = ?, price = ?, link = ?, description = ?, instructions = ?, image = ?, country = ? WHERE id = ?`
+  ).run(
+    data.title.trim(),
+    data.time_minutes || 0,
+    data.price || "0",
+    data.link || "",
+    data.description || "",
+    data.instructions?.length ? JSON.stringify(data.instructions) : null,
+    data.image || null,
+    data.country || null,
+    id
+  );
+
+  await db.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
+  await db.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
+  await saveIngredients(id, data.ingredients);
+  await saveTags(id, data.tags);
+  return true;
+}
+
+export async function deleteRecipe(id) {
+  await db.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
+  await db.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
+  await db.prepare(`DELETE FROM recipes WHERE id = ?`).run(id);
+}
+
+export async function listIngredients() {
+  return db.prepare(`SELECT id, name FROM ingredients`).all();
+}
+
+export async function listTags() {
+  return db.prepare(`SELECT id, name FROM tags`).all();
+}

--- a/frontend/src/api/recipes.js
+++ b/frontend/src/api/recipes.js
@@ -1,0 +1,40 @@
+const BASE = '/api/recipe/recipes'
+
+async function request(url, options) {
+  const res = await fetch(url, options)
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`)
+  if (res.status === 204) return null
+  return res.json()
+}
+
+export function listRecipes() {
+  return request(`${BASE}/`)
+}
+
+export function getRecipe(id) {
+  return request(`${BASE}/${id}/`)
+}
+
+export function listRecipesByCountry(countryId) {
+  return request(`${BASE}/country/${countryId}`)
+}
+
+export function createRecipe(payload) {
+  return request(`${BASE}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+export function updateRecipe(id, payload) {
+  return request(`${BASE}/${id}/`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+export function deleteRecipe(id) {
+  return request(`${BASE}/${id}/`, { method: 'DELETE' })
+}

--- a/frontend/src/components/CountryPanel.jsx
+++ b/frontend/src/components/CountryPanel.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import RecipeCard from './RecipeCard'
+import { listRecipesByCountry } from '../api/recipes'
 
 export default function CountryPanel({ country, onClose }) {
   const [recipes, setRecipes]   = useState([])
@@ -12,8 +13,7 @@ export default function CountryPanel({ country, onClose }) {
     setLoading(true)
     setError(null)
     setRecipes([])
-    fetch(`/api/recipe/recipes/country/${country.id}`)
-      .then(r => { if (!r.ok) throw new Error(); return r.json() })
+    listRecipesByCountry(country.id)
       .then(data => { setRecipes(data); setLoading(false) })
       .catch(() => { setError('Kunne ikke hente opskrifter.'); setLoading(false) })
   }, [country])

--- a/frontend/src/pages/RecipeDetail.jsx
+++ b/frontend/src/pages/RecipeDetail.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { getRecipe, deleteRecipe } from '../api/recipes'
 
 export default function RecipeDetail() {
   const { id }       = useParams()
@@ -10,8 +11,7 @@ export default function RecipeDetail() {
 
   useEffect(() => {
     setLoading(true)
-    fetch(`/api/recipe/recipes/${id}/`)
-      .then(r => { if (!r.ok) throw new Error(); return r.json() })
+    getRecipe(id)
       .then(data => { setRecipe(data); setLoading(false) })
       .catch(() => { setError('Kunne ikke hente opskrift.'); setLoading(false) })
   }, [id])
@@ -19,8 +19,7 @@ export default function RecipeDetail() {
   const handleDelete = async () => {
     if (!confirm(`Slet "${recipe.title}"?`)) return
     try {
-      const res = await fetch(`/api/recipe/recipes/${id}/`, { method: 'DELETE' })
-      if (!res.ok) throw new Error()
+      await deleteRecipe(id)
       navigate('/recipes')
     } catch {
       setError('Kunne ikke slette opskriften. Prøv igen.')

--- a/frontend/src/pages/RecipeForm.jsx
+++ b/frontend/src/pages/RecipeForm.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
+import { getRecipe, createRecipe, updateRecipe } from '../api/recipes'
 
 const EMPTY = {
   title: '', description: '', time_minutes: '', price: '', link: '', image: '',
@@ -40,8 +41,7 @@ export default function RecipeForm() {
   useEffect(() => {
     if (isEdit && !location.state?.recipe) {
       setLoading(true)
-      fetch(`/api/recipe/recipes/${id}/`)
-        .then(r => { if (!r.ok) throw new Error(); return r.json() })
+      getRecipe(id)
         .then(data => { setForm(toForm(data)); setLoading(false) })
         .catch(() => { setError('Kunne ikke hente opskriften.'); setLoading(false) })
     }
@@ -86,15 +86,9 @@ export default function RecipeForm() {
     }
 
     try {
-      const url    = isEdit ? `/api/recipe/recipes/${id}/` : '/api/recipe/recipes/'
-      const method = isEdit ? 'PUT' : 'POST'
-      const res = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-      if (!res.ok) throw new Error()
-      const saved = await res.json()
+      const saved = isEdit
+        ? await updateRecipe(id, payload)
+        : await createRecipe(payload)
       navigate(`/recipes/${saved.id || id}`)
     } catch {
       setError('Kunne ikke gemme opskriften. Prøv igen.')

--- a/frontend/src/pages/RecipeList.jsx
+++ b/frontend/src/pages/RecipeList.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { listRecipes } from '../api/recipes'
 
 export default function RecipeList() {
   const navigate = useNavigate()
@@ -10,8 +11,7 @@ export default function RecipeList() {
   const [activeTag, setActiveTag] = useState(null)
 
   useEffect(() => {
-    fetch('/api/recipe/recipes/')
-      .then(r => r.json())
+    listRecipes()
       .then(data => { setRecipes(data); setLoading(false) })
       .catch(() => { setError('Kunne ikke hente opskrifter.'); setLoading(false) })
   }, [])


### PR DESCRIPTION
Splits app code so the concerns are clearer; no behavior change.

## What
- **Backend** — `routes/recipes.js` (284 lines, mixed HTTP + SQL) split into:
  - `backend/services/recipes.js` — DB queries + upsert helpers
  - `backend/routes/recipes.js` — thin HTTP handlers calling the service
- **Frontend** — new `frontend/src/api/recipes.js` fetch wrapper. All 5 inline `fetch('/api/recipe/...')` calls in pages / `CountryPanel` replaced with named imports (`listRecipes`, `getRecipe`, `createRecipe`, `updateRecipe`, `deleteRecipe`, `listRecipesByCountry`).

## Why
- Route file was doing HTTP parsing + validation + SQL + response shaping in one place. Splitting makes each file short enough to read in one screen and unblocks future additions (auth middleware, input validation) without touching query code.
- Inline fetch calls duplicated the `/api/recipe/recipes/` base path 5× and each rebuilt its own error handling. One wrapper = one place to change when the API contract moves.

## Scope kept tight
Not touched on purpose:
- `initDb.js` seed extraction — big diff, low review value
- `App.css` split — high regression risk for no behavior change
- Root-level docker-compose reshuffle — touches deploy paths, not worth bundling here

## Test plan
- [x] `docker compose --profile dev up -d --build` — stack builds clean
- [x] CRUD smoke via `http://localhost/api/recipe/...` — list/get/create/update/delete/country all return expected status codes
- [x] `bash scripts/security-check.sh` — passes (forbidden files / secrets / npm audit)
- [ ] CI `Security Audit` + Docker build jobs green on this PR
- [ ] Manual UI click-through on `http://localhost` after merge

## Deploy impact
Deploy pipeline unchanged. On merge, `ci-cd.yml` rebuilds + pushes the backend and frontend images and redeploys to whichever VM `DEPLOY_OWNER` points at. No schema changes, no env vars added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)