### PR TITLE
Exam-audit cleanup: security, data integrity, Docker hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,9 @@ legacy/
 
 # Environment files
 .env*
+
+# SQLite databases
+*.db
+*.sqlite
+*.sqlite3
+*.db-journal

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,8 +12,8 @@ env:
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
 
 jobs:
-  security-audit:
-    name: Security Audit
+  dependency-audit:
+    name: Dependency Audit
     runs-on: ubuntu-latest
 
     steps:
@@ -44,7 +44,7 @@ jobs:
   build-and-push:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
-    needs: security-audit
+    needs: dependency-audit
 
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ feature   ●───●   ●──●──●          (branch from dev, mer
 ### Why `master` is strict and `dev` is not
 
 - A push to `master` triggers the deploy job in `ci-cd.yml`, which SSHes into the Azure VM and restarts containers. Mistakes there are user-visible.
-- A push to `dev` only triggers `security-audit` and `build-and-push` — the images get tagged but nothing deploys. It's our integration playground.
+- A push to `dev` only triggers `dependency-audit` and `build-and-push` — the images get tagged but nothing deploys. It's our integration playground.
 
 ### Agent rules around git flow
 
@@ -184,7 +184,7 @@ chmod +x .git/hooks/pre-push
 - **To `dev`:** no PR required. Direct pushes or feature-branch merges both fine. Still run the security check first.
 - Use the repo's `PULL_REQUEST_TEMPLATE.md`. Fill in **all** three sections (what / why / how tested).
 - A PR that changes CI/CD (`.github/workflows/**`), infra (`infrastructure/**`), or any `Dockerfile` requires an explicit note in the PR body calling that out. The agent should never sneak these in alongside feature work.
-- Agents should open PRs to `master` as **draft** by default, and only mark ready once the local security check and the CI `security-audit` job both pass cleanly.
+- Agents should open PRs to `master` as **draft** by default, and only mark ready once the local security check and the CI `dependency-audit` job both pass cleanly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ for the full flow and the `FORCE=1` override.
 [`ci-cd.yml`](./.github/workflows/ci-cd.yml) runs on push to
 `master`/`dev` and on `workflow_dispatch`:
 
-1. **security-audit** — `npm audit` on backend + frontend.
+1. **dependency-audit** — `npm audit` on backend + frontend.
 2. **build-and-push** — builds backend + frontend images, pushes to
    `ghcr.io/balladebaderne/cookbook-{backend,frontend}`.
 3. **deploy** — only on `master` or manual dispatch. Picks one path

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,21 +1,13 @@
-# ---------- BUILD STAGE ----------
-FROM node:18-alpine AS backend-builder
-
-WORKDIR /app/backend
-
-# Copy the entire backend directory
-COPY backend/ ./
-
-# Install dependencies
-RUN npm install --production || true
-
-# ---------- RUNTIME STAGE ----------
 FROM node:18-alpine
 
 WORKDIR /app/backend
 
-# Copy only the backend code from the build stage
-COPY --from=backend-builder /app/backend ./
+# Install dependencies from lockfile only (better build-cache behaviour)
+COPY backend/package.json backend/package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy the rest of the backend source
+COPY backend/ ./
 
 # Create data directory for SQLite
 RUN mkdir -p /app/data
@@ -25,9 +17,7 @@ COPY openapi.yaml /app/
 
 EXPOSE 3000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"
 
-# Start the app
 CMD ["node", "index.js"]

--- a/backend/db.js
+++ b/backend/db.js
@@ -15,6 +15,7 @@ class Database {
       if (err) console.error("Database connection error:", err);
       else console.log("Connected to SQLite database at", filename);
     });
+    this.db.run("PRAGMA foreign_keys = ON");
   }
 
   prepare(sql) {

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -15,40 +15,8 @@ router.post("/create/", async (req, res) => {
     res.status(201).json({ email, name });
   } catch (err) {
     console.error("Error creating user:", err);
-    res.status(500).json({ error: err.message });
+    res.status(500).json({ error: "Kunne ikke oprette brugeren." });
   }
-});
-
-router.get("/me/", (req, res) => {
-  console.log("Route invoked: GET /api/user/me/");
-  res.status(200).json({
-    email: "user@example.com",
-    name: "Example User"
-  });
-});
-
-router.put("/me/", (req, res) => {
-  console.log("Route invoked: PUT /api/user/me/");
-  const { email, name } = req.body;
-  res.status(200).json({ email, name });
-});
-
-router.patch("/me/", (req, res) => {
-  console.log("Route invoked: PATCH /api/user/me/");
-  const data = req.body || {};
-
-  res.status(200).json({
-    email: Object.prototype.hasOwnProperty.call(data, "email") ? data.email : "user@example.com",
-    name: Object.prototype.hasOwnProperty.call(data, "name") ? data.name : "Example User"
-  });
-});
-
-router.post("/token/", (req, res) => {
-  console.log("Route invoked: POST /api/user/token/");
-  const { email } = req.body;
-
-  // stub — never return the password
-  res.status(200).json({ email, token: "stub-token" });
 });
 
 export default router;

--- a/backend/services/recipes.js
+++ b/backend/services/recipes.js
@@ -142,48 +142,62 @@ export async function getRecipe(id) {
 }
 
 export async function createRecipe(data) {
-  const result = await db.prepare(
-    `INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    data.title.trim(),
-    data.time_minutes || 0,
-    data.price || "0",
-    data.link || "",
-    data.description || "",
-    data.instructions?.length ? JSON.stringify(data.instructions) : null,
-    data.image || null,
-    data.country || null
-  );
+  await db.exec("BEGIN TRANSACTION");
+  try {
+    const result = await db.prepare(
+      `INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      data.title.trim(),
+      data.time_minutes || 0,
+      data.price || "0",
+      data.link || "",
+      data.description || "",
+      data.instructions?.length ? JSON.stringify(data.instructions) : null,
+      data.image || null,
+      data.country || null
+    );
 
-  const recipeId = result.lastInsertRowid;
-  await saveIngredients(recipeId, data.ingredients);
-  await saveTags(recipeId, data.tags);
-  return recipeId;
+    const recipeId = result.lastInsertRowid;
+    await saveIngredients(recipeId, data.ingredients);
+    await saveTags(recipeId, data.tags);
+    await db.exec("COMMIT");
+    return recipeId;
+  } catch (err) {
+    await db.exec("ROLLBACK").catch(() => {});
+    throw err;
+  }
 }
 
 export async function updateRecipe(id, data) {
   const existing = await db.prepare(`SELECT id FROM recipes WHERE id = ?`).get(id);
   if (!existing) return false;
 
-  await db.prepare(
-    `UPDATE recipes SET title = ?, time_minutes = ?, price = ?, link = ?, description = ?, instructions = ?, image = ?, country = ? WHERE id = ?`
-  ).run(
-    data.title.trim(),
-    data.time_minutes || 0,
-    data.price || "0",
-    data.link || "",
-    data.description || "",
-    data.instructions?.length ? JSON.stringify(data.instructions) : null,
-    data.image || null,
-    data.country || null,
-    id
-  );
+  await db.exec("BEGIN TRANSACTION");
+  try {
+    await db.prepare(
+      `UPDATE recipes SET title = ?, time_minutes = ?, price = ?, link = ?, description = ?, instructions = ?, image = ?, country = ? WHERE id = ?`
+    ).run(
+      data.title.trim(),
+      data.time_minutes || 0,
+      data.price || "0",
+      data.link || "",
+      data.description || "",
+      data.instructions?.length ? JSON.stringify(data.instructions) : null,
+      data.image || null,
+      data.country || null,
+      id
+    );
 
-  await db.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
-  await db.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
-  await saveIngredients(id, data.ingredients);
-  await saveTags(id, data.tags);
-  return true;
+    await db.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
+    await db.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
+    await saveIngredients(id, data.ingredients);
+    await saveTags(id, data.tags);
+    await db.exec("COMMIT");
+    return true;
+  } catch (err) {
+    await db.exec("ROLLBACK").catch(() => {});
+    throw err;
+  }
 }
 
 export async function deleteRecipe(id) {

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -17,8 +17,6 @@ ADMIN_USER="${ADMIN_USER:-azureuser}"
 
 GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
 
-APP_PORT=3000
-
 log() { printf '\n\033[1;34m[setup]\033[0m %s\n' "$*"; }
 die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 
@@ -136,10 +134,10 @@ else
 fi
 
 # ---------- NSG rules ----------
-log "Opening ports 80, 443, and $APP_PORT on '$VM_NAME'..."
-az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 80        --priority 1001 --output none || true
-az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 443       --priority 1002 --output none || true
-az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port "$APP_PORT" --priority 1003 --output none || true
+# Backend port 3000 is intentionally NOT opened — nginx reverse-proxies /api from inside cookbook-network.
+log "Opening ports 80 and 443 on '$VM_NAME'..."
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 80  --priority 1001 --output none || true
+az vm open-port --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --port 443 --priority 1002 --output none || true
 
 # ---------- IP lookup ----------
 log "Fetching IP address..."
@@ -208,7 +206,7 @@ cat <<SUMMARY
 Single-VM deployment provisioned:
   Resource group: $RESOURCE_GROUP
   VM:             $VM_NAME ($VM_IP)
-  Open ports:     80, 443, $APP_PORT
+  Open ports:     80, 443
 
 GitHub secrets set on $GITHUB_REPO:
   SSH_USER, SSH_HOST, SSH_PRIVATE_KEY

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -98,6 +98,31 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/recipe/recipes/country/{country}/:
+    get:
+      summary: Get recipes by country
+      operationId: getRecipesByCountry
+      tags: [Recipes]
+      parameters:
+        - name: country
+          in: path
+          required: true
+          description: Country name (matches the recipes.country column)
+          schema:
+            type: string
+            example: Italien
+      responses:
+        '200':
+          description: List of recipes for that country
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Recipe'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/recipe/recipes/{id}/:
     get:
       summary: Get a recipe by ID
@@ -207,66 +232,6 @@ paths:
                 $ref: '#/components/schemas/User'
         '500':
           $ref: '#/components/responses/ServerError'
-
-  /api/user/token/:
-    post:
-      summary: Get auth token
-      operationId: getToken
-      tags: [Users]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                password:
-                  type: string
-      responses:
-        '200':
-          description: Token returned
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  email:
-                    type: string
-                  token:
-                    type: string
-
-  /api/user/me/:
-    get:
-      summary: Get current user
-      operationId: getMe
-      tags: [Users]
-      responses:
-        '200':
-          description: Current user
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-
-    put:
-      summary: Update current user
-      operationId: updateMe
-      tags: [Users]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserInput'
-      responses:
-        '200':
-          description: User updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
 
 components:
   parameters:


### PR DESCRIPTION
## What was done?

Cleanup-only pass against the exam-readiness audit. No new features; only fixes/removals of code already in the repo.

- **refactor(api):** remove stub `GET/PUT/PATCH /api/user/me/` and `POST /api/user/token/` routes (all returned hard-coded fake data); drop matching paths from `openapi.yaml`; add the missing `GET /api/recipe/recipes/country/{country}/` that was implemented but undocumented; swap `err.message` leak for a generic Danish error on `POST /api/user/create/`
- **fix(backend):** enable `PRAGMA foreign_keys = ON` on DB connect so `FOREIGN KEY` clauses in `initDb.js` are no longer decorative; wrap `createRecipe` and `updateRecipe` in `BEGIN`/`COMMIT`/`ROLLBACK` so a crash mid-operation can't leave orphaned rows in `recipe_ingredients`/`recipe_tags`
- **chore(docker):** collapse `backend/Dockerfile` multi-stage into one (the runtime stage was copying the full builder output including `node_modules`, so the second stage earned nothing); replace `npm install --production || true` with `npm ci --omit=dev`; split deps install into its own layer for cache reuse; add `*.db`, `*.sqlite`, `*.sqlite3`, `*.db-journal` to root `.dockerignore`
- **chore(infra):** stop opening NSG port 3000 in `infrastructure/create_vm.sh` — nothing legitimate needs the backend exposed publicly; frontend nginx still reaches it over `cookbook-network`
- **chore(ci):** rename workflow job `security-audit` → `dependency-audit` (it only runs `npm audit`, not tests); update references in `AGENTS.md` and `README.md`

## Why was this change needed?

The audit flagged a mix of:
- spec-drift and lying endpoints (`/me/` returned fake data; `/country/` wasn't in the spec at all)
- data-integrity gaps (FKs off by default; multi-table recipe writes not transactional)
- Docker footguns (`|| true` hiding install failures; dev DB files could be baked into prod images)
- a single-VM firewall rule that undermined the two-VM topology's private-backend argument
- a CI job name that overstated what it does

Shipping this gives the team a clean slate before the next group session.

## How was it tested?

- `docker compose --profile dev up -d --build` — backend built cleanly with `npm ci` (0 vulnerabilities), SQLite migrations ran, healthcheck passed
- Smoke-tested through the nginx proxy at `http://localhost/`:
  - `/`, `/api`, `/api/recipe/recipes/`, `/api/recipe/recipes/1/`, `/api/recipe/recipes/country/italy`, `/apidocs/` all 200
  - removed `/api/user/me/` and `/api/user/token/` now 404 (confirming stubs are gone)
  - `POST /api/recipe/recipes/` with ingredients + tags returned 201 (transactional path); `DELETE` returned 204 (FK-enforced cleanup path)
- `bash scripts/security-check.sh` passes: no forbidden files, no secret patterns, `npm audit` clean at `level=high` on both backend + frontend
- Stack torn down cleanly after testing

## ⚠️ Protected paths touched (per AGENTS.md §5)

This PR modifies each of the paths AGENTS.md says require an explicit call-out:

- `.github/workflows/ci-cd.yml` — job rename only (`security-audit` → `dependency-audit`, plus the `needs:` reference in `build-and-push`). No deploy logic changed.
- `infrastructure/create_vm.sh` — removed the `az vm open-port … --port 3000` line and the now-unused `APP_PORT` var. Does not affect the two-VM script.
- `backend/Dockerfile` — collapsed multi-stage, switched to `npm ci`, added a separate COPY-package-then-install layer for caching.

Merging to `master` will trigger `ci-cd.yml` → deploy to the Azure VM per `DEPLOY_MODE`. Review CI run before marking this PR ready.

---

## Checklist

- [x] Code works locally (docker compose dev stack, end-to-end)
- [x] No obvious errors (backend + nginx logs clean during smoke test)
- [x] Teammates can understand the change (5 atomic commits on feature branch; this PR body spells out each group)
- [x] Local `scripts/security-check.sh` passes
- [ ] CI `dependency-audit` passes (check after PR opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)