### PR TITLE
chore(repo): tighten AI-agent guardrails + add CODEOWNERS/SECURITY.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -qE 'git[[:space:]]+push.*[[:space:]:]master([[:space:]]|$)'; then echo 'BLOCKED by .claude/settings.json: pushing to master is forbidden (AGENTS.md §1 — master is PR-only and auto-deploys to the Azure VM). Open a PR from release/* or hotfix/* instead.' >&2; exit 2; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS — review routing for pull requests.
+# Format: <path-pattern> <space-separated owners>
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-configuration/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo.
+# Expand this list with the rest of the group as PRs come in.
+*                       @KINGINTHECASTE123
+
+# Sensitive areas: CI/CD, infra, prod compose files, and the legacy reference
+# implementation. AGENTS.md forbids modifying these without explicit approval —
+# CODEOWNERS makes the review requirement explicit on the GitHub side too.
+/.github/workflows/     @KINGINTHECASTE123
+/infrastructure/        @KINGINTHECASTE123
+/docker-compose.single-vm.yml   @KINGINTHECASTE123
+/docker-compose.nginx.yml       @KINGINTHECASTE123
+/docker-compose.backend.yml     @KINGINTHECASTE123
+/legacy/                @KINGINTHECASTE123

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,6 +1,8 @@
 ---
 name: General Issue
 about: Create a task, bug or improvement
+title: '[TASK] '
+labels: ['triage']
 ---
 
 # Issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,8 @@ Describe how you checked that it works.
 
 ## Checklist
 
-- [ ] Code works locally
+- [ ] Code works locally (Docker compose `dev` profile comes up clean)
+- [ ] Ran `bash scripts/security-check.sh` and it passed
 - [ ] No obvious errors
 - [ ] Teammates can understand the change
+- [ ] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,242 +1,117 @@
 # AGENTS.md — Guardrails for AI Coding Agents
 
-> **Canonical rules for any AI agent (Claude Code, Codex, Cursor, Copilot, Jules, etc.) working in this repository.**
-> If you are an AI agent, you MUST read this file top-to-bottom **before** reading any other file and before making any change. Human contributors may read it too — it doubles as onboarding.
+> Canonical rules for any AI agent (Claude Code, Codex, Cursor, Copilot, etc.) working in this repo.
+> Read this top-to-bottom **before** reading other files or making any change. Human contributors may read it too.
 
 Repository: <https://github.com/Balladebaderne/cookbook>
 
 ---
 
-## 0. Prime directive: understand before you act
+## 0. Pre-flight — do this every session
 
-Before proposing, writing, or running anything, an agent MUST complete this pre-flight checklist. No exceptions — not even for "tiny" changes.
+1. Read [`README.md`](./README.md).
+2. Read **this file** in full.
+3. Read [`openapi.yaml`](./openapi.yaml) — source of truth for the HTTP API.
+4. Check git state: `git branch --show-current` and `git status`.
+5. If the task touches CI/CD or deploy, read [`.github/workflows/ci-cd.yml`](./.github/workflows/ci-cd.yml) first.
 
-1. Read `README.md` at the repo root.
-2. Read **this file** (`AGENTS.md`) in full.
-3. Read `openapi.yaml` — it is the source of truth for the backend API contract.
-4. Check the current git state:
-   ```bash
-   git branch --show-current
-   git status
-   git log --oneline -10
-   ```
-5. Read `backend/package.json` and `frontend/package.json` to know what runtime + deps exist.
-6. Read the Docker Compose file(s) relevant to the task:
-   - Local work → `docker-compose.yml` (profile `dev`)
-   - Single-VM prod → `docker-compose.single-vm.yml`
-   - Two-VM prod → `docker-compose.nginx.yml` + `docker-compose.backend.yml`
-7. If the task touches CI/CD or deploy, read `.github/workflows/ci-cd.yml` first.
-8. Summarize back to the human what you understood and what you intend to do **before** touching files. Wait for confirmation on anything non-trivial.
-
-If any of the above files are missing or contradictory, stop and ask. Do not guess.
+If anything is missing or contradictory, stop and ask.
 
 ---
 
-## 1. Project at a glance
+## 1. Git flow
 
-**Cookbook** is a full-stack recipe app.
+`master` auto-deploys to the Azure VM, so it is **PR-only**. `dev` is the shared integration branch.
 
-| Layer          | Tech                                                    |
-| -------------- | ------------------------------------------------------- |
-| Backend        | Node.js 18, Express, SQLite3, OpenAPI 3.0 (swagger-ui)  |
-| Frontend       | React 19 (Vite), react-three/fiber, served by nginx     |
-| Infra          | Azure VMs (Ubuntu 22.04), Docker, Docker Compose        |
-| CI/CD          | GitHub Actions → GHCR → SSH deploy to VM                |
+| Branch       | Branches from | Merges into     | PR required?         |
+| ------------ | ------------- | --------------- | -------------------- |
+| `master`     | —             | —               | **Yes — always.**    |
+| `dev`        | `master` (init) | —             | No. Direct pushes OK. |
+| `feature/*`  | `dev`         | `dev`           | Optional.            |
+| `release/*`  | `dev`         | `master` + `dev` | Yes (to `master`).   |
+| `hotfix/*`   | `master`      | `master` + `dev` | Yes (to `master`).   |
 
-Two deploy topologies live side-by-side:
-- **Single VM** — one host runs both containers (`docker-compose.single-vm.yml`)
-- **Two VMs** — public nginx host + internal backend host (`docker-compose.nginx.yml` + `docker-compose.backend.yml`)
+**Branch naming:** `feature/<kebab-slug>`, `hotfix/<kebab-slug>`, `release/<semver>`.
 
-Which one ships is controlled by the repo variable `DEPLOY_MODE` (`single` or `two-vms`).
-
-The `legacy/` folder contains an old Python/Flask implementation kept for reference. **Do not modify `legacy/`** unless the human explicitly asks.
-
----
-
-## 2. Git flow — this is non-negotiable
-
-We use Git Flow. The **critical rule** is that **merging into `master` is what triggers production deployment**, so `master` is gated behind a pull request. `dev` is the shared integration branch — pushes there are allowed, but feature work should still go through feature branches whenever practical.
-
-```
-master   ──●───────────────●──────●──→  (production — PR-only, auto-deploys)
-            \             / \    /
-hotfix       \           /   ●──/  (branch from master, PR to master + back-merge to dev)
-              \         /
-release        \       ●──●        (branch from dev, PR to master + back-merge to dev)
-                \     /    \
-dev   ──●───●───●───●──────●──→    (integration — CI builds, no deploy)
-         \     / \
-feature   ●───●   ●──●──●          (branch from dev, merge back into dev)
-```
-
-### Branch rules
-
-| Branch        | Branches from   | Merges into           | PR required?                 |
-| ------------- | --------------- | --------------------- | ---------------------------- |
-| `master`      | —               | —                     | **Yes — always.** No direct pushes, ever. |
-| `dev`         | `master` (init) | —                     | Not required. Direct pushes allowed. |
-| `feature/*`   | `dev`           | `dev`                 | Optional — team preference. Fast-forward / squash merge is fine. |
-| `release/*`   | `dev`           | `master` **and** `dev` | **Yes** — for the master side. |
-| `hotfix/*`    | `master`        | `master` **and** `dev` | **Yes** — for the master side. |
-
-### Why `master` is strict and `dev` is not
-
-- A push to `master` triggers the deploy job in `ci-cd.yml`, which SSHes into the Azure VM and restarts containers. Mistakes there are user-visible.
-- A push to `dev` only triggers `dependency-audit` and `build-and-push` — the images get tagged but nothing deploys. It's our integration playground.
-
-### Agent rules around git flow
-
-- **Never** `git push` (or propose a push) to `master`. Ever. The only way code reaches `master` is via a merged PR.
-- Pushes to `dev` are allowed, but **prefer the feature-branch route** for anything non-trivial: branch from `dev`, do the work, merge back to `dev`.
-- For hotfixes: branch from `master`, open a PR back to `master`, and after it merges, cherry-pick or merge the same commits into `dev` so the two branches don't diverge.
-- For releases: branch from `dev` as `release/<semver>`, stabilize, open a PR to `master`, then back-merge to `dev`.
-- If the current branch is `master` and the user asks for code changes, switch before editing:
-  ```bash
-  git checkout dev && git pull
-  git checkout -b feature/<slug>   # or hotfix/<slug> depending on intent
-  ```
-- Before creating a branch, ask the human for the name if it wasn't given, and confirm the base (`dev` for feature/release, `master` for hotfix).
-
-### Branch naming
-
-- `feature/<short-kebab-slug>` — e.g. `feature/add-recipe-tags`
-- `hotfix/<short-kebab-slug>` — e.g. `hotfix/null-recipe-id`
-- `release/<semver>` — e.g. `release/1.2.0`
-
----
-
-## 3. Local development workflow
-
-We test locally with Docker, **not** raw `npm start`. The `dev` profile of the root compose file is the canonical way.
+**Rule:** never push to `master`. The only path in is a merged PR. If the current branch is `master` and the user asks for code changes, switch first:
 
 ```bash
-# Start (from repo root)
-docker compose --profile dev up -d --build
-
-# Tail logs
-docker compose --profile dev logs -f
-
-# Stop
-docker compose --profile dev down
+git checkout dev && git pull
+git checkout -b feature/<slug>
 ```
-
-Endpoints:
-- Frontend: <http://localhost>
-- Backend API: <http://localhost:3000/api>
-- Swagger UI: <http://localhost:3000/apidocs>
-
-**Agent rules:**
-- Prefer Docker for running the app. Do not start raw `node` or `vite dev` servers unless debugging a specific issue that requires it, and only after telling the human.
-- If you change a `Dockerfile`, `package.json`, or `docker-compose*.yml`, you MUST rebuild with `--build` and verify the stack still comes up clean before handing back.
-- If you change the SQLite schema in `backend/initDb.js`, mention that local volumes may need to be wiped (`docker compose --profile dev down -v`) and flag this in the PR / commit message.
 
 ---
 
-## 4. Security gate — run this before every push
+## 2. Local development
 
-The CI pipeline runs `npm audit --audit-level=high` on both packages. That's the backstop, not the first line of defense. The agent MUST run a local security check **before** every `git push` — including pushes to `dev` — and the check must pass.
+Use Docker, not raw `npm` / `vite`:
 
-A helper script is provided:
+```bash
+docker compose --profile dev up -d --build   # start
+docker compose --profile dev logs -f          # tail
+docker compose --profile dev down             # stop
+```
+
+Frontend: <http://localhost> · API: <http://localhost:3000/api> · Swagger: <http://localhost:3000/apidocs>
+
+If you change a `Dockerfile`, `package.json`, or any compose file, rebuild with `--build` and verify the stack still comes up clean. If you change the SQLite schema in `backend/initDb.js`, flag that local volumes may need wiping (`docker compose --profile dev down -v`).
+
+---
+
+## 3. Security gate
+
+Run **before every push**, including pushes to `dev`:
 
 ```bash
 bash scripts/security-check.sh
 ```
 
-### What it checks (enforced)
+It checks: forbidden files (`.env`, `*.db`, `*.pem`, `node_modules/`, `dist/`), secret patterns (AWS keys, GitHub PATs, Slack tokens, private keys, etc.), and `npm audit --audit-level=high` in both `backend/` and `frontend/`.
 
-1. **Branch check** — hard-fails if the current branch is `master`. Warns on `main`/`dev`/`develop` or on non-git-flow names.
-2. **Forbidden files** — blocks if any of these are tracked or staged:
-   - `node_modules/`, `dist/`, `build/`
-   - `*.db`, `*.sqlite`, `*.sqlite3`, `*.db-journal`
-   - `.env`, `.env.*` (but `.env.example` is allowed)
-   - `*.pem`, `*.key`, `id_rsa*`
-   - `docker-compose.override.yml`
-3. **Secret pattern scan** — blocks on:
-   - `-----BEGIN (RSA|OPENSSH|EC|DSA|PGP) PRIVATE KEY-----`
-   - AWS access keys (`AKIA...`)
-   - GitHub PATs (`ghp_...`, `github_pat_...`)
-   - Slack tokens (`xox[baprs]-...`)
-   - Generic assignments like `password = "..."`, `api_key = "..."` with non-placeholder values
-4. **Dependency audit** — `npm audit --audit-level=high` in `backend/` AND `frontend/`. Any `high` or `critical` blocks the push.
-5. **Dockerfile sanity** — warns on unpinned base images, `ADD http...`, or `curl | sh` patterns.
-6. **.gitignore present** — warns if absent or clearly weakened.
+On any failure: do not push. Fix the issue, or surface it to the human if it needs a decision. **Never** bypass with `--no-verify` or by lowering `--audit-level`.
 
-### On any failure
-
-- Do not push.
-- Report which check failed, with the exact offending file/line.
-- Propose a fix. If the fix needs a human decision (e.g. a `high` vuln with no patched version), surface it and wait for instruction.
-- **Never** bypass with `git push --no-verify` or by lowering `--audit-level`.
-
-### Recommended: wire it up as a pre-push hook
+To wire it up as an automatic pre-push hook:
 
 ```bash
-# One-time setup
-cp scripts/security-check.sh .git/hooks/pre-push
-chmod +x .git/hooks/pre-push
+cp scripts/security-check.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 ```
 
 ---
 
-## 5. Pull requests
+## 4. Pull requests
 
-- **To `master`:** always via PR, always from a `release/*` or `hotfix/*` branch (or, exceptionally, `dev` itself for a coordinated release merge). This PR is what ships to the VM — treat it as the deploy button.
-- **To `dev`:** no PR required. Direct pushes or feature-branch merges both fine. Still run the security check first.
-- Use the repo's `PULL_REQUEST_TEMPLATE.md`. Fill in **all** three sections (what / why / how tested).
-- A PR that changes CI/CD (`.github/workflows/**`), infra (`infrastructure/**`), or any `Dockerfile` requires an explicit note in the PR body calling that out. The agent should never sneak these in alongside feature work.
-- Agents should open PRs to `master` as **draft** by default, and only mark ready once the local security check and the CI `dependency-audit` job both pass cleanly.
+- **To `master`:** always via PR, from `release/*` or `hotfix/*` (or `dev` for a coordinated release merge). Treat it as the deploy button.
+- **To `dev`:** no PR required.
+- Use [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md) and fill all sections.
+- A PR that changes `.github/workflows/**`, `infrastructure/**`, or any `Dockerfile` must call that out in the body — never sneak it in alongside feature work.
+- Open PRs to `master` as **draft** by default; mark ready once `security-check.sh` and CI both pass.
 
 ---
 
-## 6. Hard nevers (agent refuses even if asked)
+## 5. Hard nevers — refuse even if asked
 
 - Push, force-push, or rebase `master`.
 - Commit secrets, `.env` files, private keys, or the SQLite DB.
 - Commit `node_modules/` or `dist/`.
-- Modify `.github/workflows/ci-cd.yml`, `infrastructure/*.sh`, or the prod compose files without an explicit, in-conversation approval from the human for that specific change.
+- Modify `.github/workflows/ci-cd.yml`, `infrastructure/*`, or the prod compose files without explicit, in-conversation approval for that specific change.
 - Edit anything under `legacy/` unless explicitly told to.
 - Weaken `.gitignore`, disable `npm audit` in CI, or lower `--audit-level`.
-- Use `git commit --no-verify` or `git push --no-verify` to bypass hooks.
-- Echo, log, or otherwise surface the contents of `~/.ssh/`, `secrets.*`, or CI secrets.
-- Add new top-level dependencies without running `npm audit` on the result and reporting the delta.
+- Use `git commit --no-verify` or `git push --no-verify`.
+- Echo, log, or surface the contents of `~/.ssh/`, `secrets.*`, or CI secrets.
 
-If the human asks for one of these, the agent should refuse, explain which rule applies, and propose the correct path (e.g. "I can't push to master, but I can open a PR from `release/1.2.0` into `master`").
-
----
-
-## 7. Commit messages
-
-Short, imperative, present tense. Conventional Commits preferred but not mandatory.
-
-```
-feat(backend): add GET /api/recipe/:id/tags
-fix(frontend): null-check recipe author on list view
-chore(ci): bump setup-node to v4
-```
-
-One logical change per commit. Don't mix formatting with logic.
+If asked to do one of these: refuse, name the rule, propose the correct path (e.g. "I can't push to `master`, but I can open a PR from `release/1.2.0`").
 
 ---
 
-## 8. Adding or updating dependencies
+## 6. Conventions
 
-1. Work on a feature branch (or `dev` for small bumps).
-2. `npm install <pkg>` (or `npm install <pkg>@<exact>` — prefer exact versions for new direct deps).
-3. Commit **both** `package.json` and `package-lock.json`.
-4. Run `npm audit --audit-level=high` in that package — it must pass.
-5. Run `bash scripts/security-check.sh` from repo root.
-6. Note the dep (name, version, why) in the commit message or PR description.
-
-In CI we use `npm ci`, not `npm install` — don't change that.
+- **Commits:** short, imperative, present tense. Conventional Commits preferred (`feat(...)`, `fix(...)`, `chore(...)`). One logical change per commit — don't mix formatting with logic.
+- **Dependencies:** commit `package.json` and `package-lock.json` together. Prefer exact versions for new direct deps. Run `npm audit --audit-level=high` after install. CI uses `npm ci` — don't change that.
+- **API contract:** [`openapi.yaml`](./openapi.yaml) is the source of truth. Update the spec in the same commit as the handler — Swagger UI serves this file directly, so drift is a user-visible bug.
+- **`legacy/`:** old Python/Flask reference implementation. Do not modify.
 
 ---
 
-## 9. API contract
-
-`openapi.yaml` at the repo root is the **source of truth** for the HTTP API. If you change an endpoint, update the spec in the same commit as the handler. Swagger UI at `/apidocs` serves this file directly, so a drift between code and spec is a user-visible bug.
-
----
-
-## 10. When in doubt
+## 7. When in doubt
 
 Stop. Ask. A thirty-second clarification beats a thirty-minute revert.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Scope of this project
+
+Cookbook is a 4th-semester IT-Architecture exam project. The `master` branch auto-deploys to a small Azure VM used for grading and demos — it is not a production service and handles no real user data.
+
+## Reporting a vulnerability
+
+If you find a security issue, please open a private [security advisory](https://github.com/Balladebaderne/cookbook/security/advisories/new) on GitHub rather than a public issue.
+
+We aim to acknowledge reports within 7 days. As a coursework project, we cannot guarantee fixes, but credible reports will be triaged and noted in the repository.
+
+## In scope
+
+- `backend/` (Node/Express + SQLite)
+- `frontend/` (React/Vite)
+- `.github/workflows/` (CI/CD)
+- `infrastructure/` and the Docker Compose deploy files
+- `openapi.yaml`
+
+## Out of scope
+
+- The `legacy/` Python/Flask reference implementation — kept for course continuity, not maintained.
+- Third-party dependencies — please report upstream. If a `npm audit` finding has no patched version, open an issue here so we can document the risk.
+- The underlying Azure VM and its OS-level configuration.
+
+## What we already do
+
+- `npm audit --audit-level=high` runs on every push (CI) and is part of the local pre-push gate ([`scripts/security-check.sh`](./scripts/security-check.sh)).
+- Secret-pattern scanning and forbidden-file checks run in the same pre-push gate.
+- `master` is PR-only; no direct pushes. See [`AGENTS.md`](./AGENTS.md) for the full guardrails.


### PR DESCRIPTION
## What was done?

Brings the repo's GitHub-side guardrails up to the same bar as the local `AGENTS.md` + `security-check.sh` setup. No runtime code touched.

- Slim `AGENTS.md` from 240 → 117 lines (drop redundant prose, fold dependency workflow into conventions)
- Add `SECURITY.md` with scope, reporting flow, and existing-controls summary
- Add `.github/CODEOWNERS` for review routing; flags CI/infra/legacy paths explicitly
- Add `.claude/settings.json` with a `PreToolUse` hook that blocks `git push *master` (defense-in-depth for AGENTS.md §1)
- Update `.github/PULL_REQUEST_TEMPLATE.md` with a security-check checkbox and a CI/infra-touched callout
- Auto-prefix `[TASK]` title and apply `triage` label in `.github/ISSUE_TEMPLATE/issue.md`

## Why was this change needed?

`AGENTS.md` and `scripts/security-check.sh` were already solid, but the GitHub-side surface — CODEOWNERS, SECURITY.md, PR template — was thin. Once this lands on `master`, future PRs inherit the new template and CODEOWNERS routing automatically (GitHub reads both from the default branch).

This PR also clears the way for the next round of work (backend architecture refactor: split `initDb.js`, add error-handling middleware, add tests) to open against a clean master with the new tooling already in place.

## How was it tested?

- `bash scripts/security-check.sh` — passes on this branch (forbidden-files OK, secret-scan OK, `npm audit --audit-level=high` clean on both `backend/` and `frontend/`).
- `.claude/settings.json` hook validated with `jq -e` schema check + 6-case pipe-test:
  - blocks: `git push origin master`, `git push --force origin HEAD:master`, `git push -f origin master`
  - allows: `git push origin dev`, `git push origin feature/master-cleanup`, `git status`
- `AGENTS.md` re-read end-to-end after slim — all rules from the original (pre-flight, branch table, security gate, hard nevers, conventions) preserved.

## Notes for review

- This PR does **not** touch `.github/workflows/`, `infrastructure/`, or any `Dockerfile`. Auto-deploy will rebuild Docker images, but they're functionally identical to what's currently running on the VM.
- The PR template you're reading is the *old* one — the new template (with the security-check checkbox) only takes effect for PRs opened after this lands.