### PR TITLE
fix(infra): make VM setup scripts work on macOS bash 3.2 + Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF on shell scripts so Windows checkouts (with core.autocrlf=true)
+# don't end up with CRLF, which makes bash fail with cryptic errors like
+# "'\r': command not found" or heredoc syntax errors.
+*.sh text eol=lf

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -29,6 +29,19 @@ Install and configure on your local machine:
   `CR_PAT` (only needed if you pull images on the VM manually; the
   pipeline uses the ephemeral `GITHUB_TOKEN`)
 
+### Operating systems
+
+- **macOS / Linux:** kør scripts direkte med `bash infrastructure/...`.
+- **Windows:** kør via **WSL** (anbefalet) eller **Git Bash** — ikke
+  PowerShell eller `cmd`. Scripts bruger bash-arrays, heredocs og
+  `set -euo pipefail`, som ikke findes i PowerShell. WSL/Git Bash
+  bundler bash 5.x og kan finde `az` / `gh` på PATH når de er
+  installeret normalt på Windows.
+
+  Repoet har en `.gitattributes` der tvinger LF på `*.sh`, så CRLF-
+  konvertering (Git's default `core.autocrlf=true` på Windows) ikke
+  bryder scripts med fejl som `'\r': command not found`.
+
 ## One active deployment at a time
 
 The repo's deploy secrets (`SSH_HOST*`, `BACKEND_PRIVATE_IP`,

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -228,7 +228,9 @@ wait_for_ssh() {
   [[ -n "$jump_host" ]] && extra=(-o "ProxyJump=$ADMIN_USER@$jump_host")
   log "Waiting for SSH on $host${jump_host:+ (via $jump_host)}..."
   for _ in $(seq 1 30); do
-    if ssh "${SSH_OPTS[@]}" "${extra[@]}" "$ADMIN_USER@$host" 'true' 2>/dev/null; then
+    # ${extra[@]+"${extra[@]}"} expands to nothing when the array is empty —
+    # bash 3.2 (macOS default) treats "${extra[@]}" as unbound under set -u.
+    if ssh "${SSH_OPTS[@]}" ${extra[@]+"${extra[@]}"} "$ADMIN_USER@$host" 'true' 2>/dev/null; then
       return 0
     fi
     sleep 5
@@ -242,7 +244,7 @@ provision() {
   [[ -n "$jump_host" ]] && extra=(-o "ProxyJump=$ADMIN_USER@$jump_host")
   wait_for_ssh "$host" "$jump_host"
   log "Provisioning $label ($host)${jump_host:+ via $jump_host}: base packages + Docker..."
-  ssh "${SSH_OPTS[@]}" "${extra[@]}" "$ADMIN_USER@$host" 'bash -s' <<'REMOTE'
+  ssh "${SSH_OPTS[@]}" ${extra[@]+"${extra[@]}"} "$ADMIN_USER@$host" 'bash -s' <<'REMOTE'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 sudo -E apt-get update -y


### PR DESCRIPTION
## What was done?

- `infrastructure/create_two_vms.sh`: replace `"${extra[@]}"` with `${extra[@]+"${extra[@]}"}` in `wait_for_ssh` and `provision` so empty arrays don't trip `set -u` on bash 3.2
- Add `.gitattributes` forcing `*.sh text eol=lf` so Windows checkouts with `core.autocrlf=true` don't get CRLF
- `infrastructure/README.md`: add an "Operating systems" section documenting WSL / Git Bash for Windows users

## Why was this change needed?

Our teacher (and any teammate on macOS) ran into `extra[@]: unbound variable` when running `bash infrastructure/create_two_vms.sh`. macOS ships bash 3.2, which treats `"${empty_array[@]}"` as unbound under `set -u`. Bash 4.4+ fixed this — that's why it worked for us in WSL/CI but not for him locally.

The Windows portability piece is a follow-up: same script should be runnable from a Windows clone via WSL or Git Bash without CRLF issues.

## How was it tested?

- Ran the failing expansion under `/bin/bash 3.2.57` on macOS with `set -euo pipefail` — both empty and non-empty array cases now produce the correct argv with no error
- VMs are live again (confirmed by branch owner after pulling the dev fix)
- `bash scripts/security-check.sh` passes
- Diff is small and infra-only — no app or workflow changes

## Checklist

- [x] Code works locally (Docker compose `dev` profile comes up clean — unchanged by this PR)
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above — **yes, `infrastructure/` only**

## Note on auto-deploy

Master auto-deploys to the live VMs. These changes don't touch app code or compose files, so the deploy will be effectively a no-op redeploy of the current image — safe.