### PR TITLE
fix(ci): keyscan nginx jump host so two-VM backend deploy can connect

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -159,10 +159,16 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
+          # Pre-cache the nginx (jump host) key. OpenSSH applies command-line
+          # -o options to the destination only, not to the ProxyJump hop, so
+          # the jump connection still does strict host key checking against
+          # the default known_hosts. Without this keyscan, scp/ssh below fail
+          # with "Host key verification failed" on the jump.
+          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
 
       # Backend has no public IP; reach it via nginx as an SSH jump host.
-      # StrictHostKeyChecking is off because we can't keyscan a private host
-      # from the GitHub runner, and the jump host's key isn't cached either.
+      # The destination (backend) host key can't be pre-scanned from the
+      # runner, so accept it on first contact via StrictHostKeyChecking=no.
       - name: Copy backend compose file
         run: |
           scp -i ~/.ssh/id_rsa \


### PR DESCRIPTION
## What was done?

- `.github/workflows/ci-cd.yml` (`deploy-backend` → Setup SSH): add `ssh-keyscan -H $SSH_HOST_NGINX >> ~/.ssh/known_hosts`
- Rewrite the misleading comment that claimed the missing jump-host keyscan was intentional

## Why was this change needed?

After PR #35 merged, the deploy on master failed at the "Copy backend compose file" step with:

```
Host key verification failed.
Connection closed by UNKNOWN port 65535
scp: Connection closed
```

(run #25154834424, job #73734057664)

OpenSSH applies command-line `-o` options to the **destination only**, not to the `ProxyJump` hop (per `man ssh`: *"configuration directives supplied on the command-line generally apply to the destination host and not any specified jump hosts"*). So:

- `StrictHostKeyChecking=no` and `UserKnownHostsFile=/dev/null` cover the backend (destination) ✓
- The connection to nginx (jump) still does strict host key checking against the default `~/.ssh/known_hosts`, which is empty on a fresh runner ✗

Previous deploys succeeded because the repo was running `DEPLOY_MODE=single`, which uses `deploy-single-vm` (already does ssh-keyscan). The two-VM backend path was never exercised in CI before — the bug has been latent in the workflow.

## How was it tested?

- Read `man ssh` to confirm `-o` propagation behavior on `ProxyJump`
- Compared with `deploy-single-vm` and `deploy-nginx` jobs, which both do `ssh-keyscan` on their target — pattern is now consistent across all three deploy jobs
- `bash scripts/security-check.sh` passes
- Will be verified end-to-end when this PR merges and the deploy pipeline runs against the live two-VM setup

## Checklist

- [x] Code works locally (no app/Docker changes — workflow-only fix)
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above — **yes, `.github/workflows/ci-cd.yml`**