### PR TITLE
docs+infra: make first-time deploy a one-command flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,98 @@ docker compose --profile dev down            # stop
 
 ## Deploying to Azure
 
-All Azure provisioning lives under [`infrastructure/`](./infrastructure/README.md).
-Two topologies are supported — pick one:
+End-to-end: install two CLIs, clone the repo, run one script, push to
+`master`. The script handles everything else — including opening a
+browser for `az login` / `gh auth login` if you're not already signed in.
 
-- **Single VM** — `bash infrastructure/create_vm.sh`
-- **Two VMs** (public nginx + backend with **no public IP**, reachable
-  only through nginx) — `bash infrastructure/create_two_vms.sh`
+### 1. Install prerequisites (one-time per machine)
 
-The create scripts set the repo variable `DEPLOY_MODE` so the CI/CD
-pipeline knows which deploy job to run. Push to `master` (or trigger
-`workflow_dispatch`) to deploy. Tear down with:
+You need three things on PATH: **Azure CLI** (`az`), **GitHub CLI**
+(`gh`), and an **SSH key pair** in `~/.ssh/`.
+
+#### macOS
+
+```bash
+brew install azure-cli gh
+```
+
+#### Windows
+
+Open **Git Bash** (bundles bash + ssh, ships with [Git for Windows](https://git-scm.com/download/win)).
+Then in Git Bash:
+
+```bash
+winget install --id Microsoft.AzureCLI -e
+winget install --id GitHub.cli -e
+```
+
+> Run the deploy script from **Git Bash** (or WSL) — not from
+> PowerShell or `cmd`. The script is bash and uses arrays, heredocs,
+> and `set -euo pipefail`.
+
+#### Linux (Debian / Ubuntu)
+
+```bash
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+sudo apt install gh
+```
+
+#### SSH key (all OSes)
+
+If `ls ~/.ssh/id_*` shows nothing, generate one:
+
+```bash
+ssh-keygen -t ed25519 -C "your.email@example.com"
+```
+
+Press Enter through the prompts (default path, empty passphrase is fine
+for class).
+
+### 2. Clone the repo
+
+```bash
+git clone https://github.com/Balladebaderne/cookbook.git
+cd cookbook
+```
+
+### 3. Run the setup script
+
+Pick one topology:
+
+```bash
+bash infrastructure/create_two_vms.sh   # public nginx + private backend (recommended)
+# — or —
+bash infrastructure/create_vm.sh        # single public VM
+```
+
+The script will:
+
+1. Open a browser for `az login` if you're not signed in to Azure.
+2. Walk you through `gh auth login` if you're not signed in to GitHub.
+3. Show a confirmation prompt with what it's about to provision (resource group, VMs, ports, GitHub secrets it will set). Type `y` to continue.
+4. Provision the VMs, install Docker on them, and write the deploy
+   secrets back to the GitHub repo.
+
+When it finishes it prints the public IP of the nginx VM.
+
+### 4. Trigger the deploy
+
+```bash
+git push origin master   # or open & merge a dev → master PR
+```
+
+The pipeline ([`ci-cd.yml`](./.github/workflows/ci-cd.yml)) builds
+the Docker images, pushes them to GHCR, and deploys to your VMs. App
+goes live at `http://<NGINX_IP>` once the workflow finishes (~3 min).
+
+### 5. Tear down when you're done
 
 ```bash
 bash infrastructure/azure-teardown.sh
 ```
+
+Stops the Azure billing and clears the deploy lock so the next teammate
+can run a create script.
 
 ### Only one live deployment at a time
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -16,10 +16,11 @@ create_two_vms.sh  → push to master  → app live  → azure-teardown.sh
 
 ## Prerequisites
 
-Install and configure on your local machine:
+Install on your local machine — login is handled by the create scripts
+themselves (they call `az login` / `gh auth login` for you on first run):
 
-- **Azure CLI** (`az`) — logged in with `az login`
-- **GitHub CLI** (`gh`) — logged in with `gh auth login`
+- **Azure CLI** (`az`)
+- **GitHub CLI** (`gh`)
 - **SSH key pair** in `~/.ssh/` — `id_rsa`, `id_ed25519`, or `id_ecdsa`
   (auto-detected in that order; override with `SSH_KEY_PATH` /
   `SSH_PUB_KEY_PATH` env vars). If you don't have one yet:
@@ -28,6 +29,9 @@ Install and configure on your local machine:
 - A **Personal Access Token** with `read:packages` scope available as
   `CR_PAT` (only needed if you pull images on the VM manually; the
   pipeline uses the ephemeral `GITHUB_TOKEN`)
+
+See the [root README](../README.md#1-install-prerequisites-one-time-per-machine)
+for OS-specific install commands (`brew` / `winget` / `apt`).
 
 ### Operating systems
 

--- a/infrastructure/create_two_vms.sh
+++ b/infrastructure/create_two_vms.sh
@@ -50,13 +50,19 @@ SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-${SSH_KEY_PATH}.pub}"
 [[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
 
 log "Verifying Azure login..."
-az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+if ! az account show >/dev/null 2>&1; then
+  log "Not logged in to Azure — opening browser to sign in..."
+  az login || die "Azure login failed."
+fi
 ACCOUNT_NAME=$(az account show --query name -o tsv)
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SIGNED_IN_USER=$(az account show --query user.name -o tsv)
 
 log "Verifying GitHub login..."
-gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+if ! gh auth status >/dev/null 2>&1; then
+  log "Not logged in to GitHub — starting interactive login flow..."
+  gh auth login || die "GitHub login failed."
+fi
 GH_USER=$(gh api user --jq .login)
 
 # ---------- Single-active-deployment guard ----------

--- a/infrastructure/create_vm.sh
+++ b/infrastructure/create_vm.sh
@@ -43,13 +43,19 @@ SSH_PUB_KEY_PATH="${SSH_PUB_KEY_PATH:-${SSH_KEY_PATH}.pub}"
 [[ -f "$SSH_PUB_KEY_PATH" ]] || die "SSH public key not found at $SSH_PUB_KEY_PATH"
 
 log "Verifying Azure login..."
-az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+if ! az account show >/dev/null 2>&1; then
+  log "Not logged in to Azure — opening browser to sign in..."
+  az login || die "Azure login failed."
+fi
 ACCOUNT_NAME=$(az account show --query name -o tsv)
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SIGNED_IN_USER=$(az account show --query user.name -o tsv)
 
 log "Verifying GitHub login..."
-gh auth status >/dev/null 2>&1 || die "Not logged in to GitHub. Run 'gh auth login' first."
+if ! gh auth status >/dev/null 2>&1; then
+  log "Not logged in to GitHub — starting interactive login flow..."
+  gh auth login || die "GitHub login failed."
+fi
 GH_USER=$(gh api user --jq .login)
 
 # ---------- Single-active-deployment guard ----------


### PR DESCRIPTION
## What was done?

- **`create_vm.sh` / `create_two_vms.sh`**: when the user isn't signed in to Azure or GitHub, the script now auto-launches `az login` / `gh auth login` (browser opens) instead of dying with "run X first". Same script, fewer steps for the user.
- **Root `README.md` "Deploying to Azure"**: rewritten as a numbered 5-step walkthrough with OS-specific install commands (`brew` / `winget` / `apt`), SSH-key fallback, and a clear "Git Bash, not PowerShell" note for Windows users.
- **`infrastructure/README.md`** prereqs: simplified to match (login bullet removed since the script handles it) and links to the root README for install commands so the two docs don't drift.

## Why was this change needed?

Group feedback: deploying should be as close to a one-command experience as possible — a new teammate (or our teacher reproducing the project) shouldn't have to remember which CLI to install or which login command to run before the script will do anything.

## How was it tested?

- `bash -n` on both create scripts (syntax)
- `bash scripts/security-check.sh` passes
- The `az account show` / `gh auth status` checks behave the same when already-logged-in (fast path unchanged); the new branch only kicks in on a fresh machine
- README rendered as raw markdown — links resolve, code blocks are correct

No app, workflow, or compose changes — docs + UX-only edits to the create scripts.

## Checklist

- [x] Code works locally (no app changes)
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above — **`infrastructure/create_*.sh` (intentional UX change) + `infrastructure/README.md`**