### PR TITLE
fix(ci): run dependency-audit on pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,12 @@
 # Pull Request
 
+## Linked issues
+List every issue this PR resolves so the Kanban board auto-moves the cards to Done on merge. Use `Closes #N` (one per line, or comma-separated). Leave blank only if the PR genuinely resolves no tracked issue.
+
+Closes #
+
+---
+
 ## What was done?
 Briefly describe what you changed or added.
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - master
-      - dev
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
       - dev
+  pull_request:
+    branches:
+      - master
+      - dev
   workflow_dispatch:
 
 env:
@@ -49,6 +53,10 @@ jobs:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
     needs: dependency-audit
+    # On pull requests we only want the dependency-audit gate to report — not
+    # build/push images or deploy. Skipping this job also skips the deploy-*
+    # jobs that need it (they're additionally gated on master/dispatch).
+    if: github.event_name != 'pull_request'
 
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,28 @@ cp scripts/security-check.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 
 ---
 
-## 5. Hard nevers — refuse even if asked
+## 5. Issue ↔ PR ↔ board linking
+
+The Kanban board (<https://github.com/orgs/Balladebaderne/projects/2>) auto-updates from GitHub events — but only if work is linked to issues and PRs are linked to issues. Agents are responsible for keeping that chain intact so cards flow Backlog → In progress → In review → Done without manual board edits.
+
+**Before starting any task assigned in natural language:**
+
+1. Run `gh issue list --repo Balladebaderne/cookbook --state open --limit 100` and find the issue that matches the request.
+   - **One clear match** → use it.
+   - **Multiple plausible** → ask the human which one.
+   - **No match** → ask the human whether to open a new issue first or proceed without. Do not silently invent issues, and do not silently work without one.
+
+2. When work starts, move the matching board card to **In progress** via `gh project item-edit` on the Status field. Do not require the human to drag cards manually.
+
+3. In the eventual PR body, fill the **Linked issues** section of the PR template with `Closes #N` for every issue this PR resolves. Multi-issue PRs list each one (`Closes #64, Closes #65, ...`). Do not strip the placeholder.
+
+4. After merge, GitHub's auto-close + the project's `Item closed` workflow flip cards to **Done** automatically. Do not also close issues manually — duplicate events look like noise on the timeline.
+
+**Never** backfill fake issues retroactively to make the board look more disciplined than the work actually was. Forward-linking ongoing work is hygiene; retroactive narrative-construction is dishonesty.
+
+---
+
+## 6. Hard nevers — refuse even if asked
 
 - Push, force-push, or rebase `master`.
 - Commit secrets, `.env` files, private keys, or the SQLite DB.
@@ -103,7 +124,7 @@ If asked to do one of these: refuse, name the rule, propose the correct path (e.
 
 ---
 
-## 6. Conventions
+## 7. Conventions
 
 - **Commits:** short, imperative, present tense. Conventional Commits preferred (`feat(...)`, `fix(...)`, `chore(...)`). One logical change per commit — don't mix formatting with logic.
 - **Dependencies:** commit `package.json` and `package-lock.json` together. Prefer exact versions for new direct deps. Run `npm audit --audit-level=high` after install. CI uses `npm ci` — don't change that.
@@ -112,6 +133,6 @@ If asked to do one of these: refuse, name the rule, propose the correct path (e.
 
 ---
 
-## 7. When in doubt
+## 8. When in doubt
 
 Stop. Ask. A thirty-second clarification beats a thirty-minute revert.


### PR DESCRIPTION
# Pull Request

## Linked issues
No tracked issue resolves this — it's a CI workflow hotfix (plus a docs commit already on `dev`). Left blank per template guidance ("Leave blank only if the PR genuinely resolves no tracked issue").

Closes #

---

## What was done?

- Add a `pull_request` trigger (master/dev) to `.github/workflows/ci-cd.yml` so the **Dependency Audit** gate actually runs and reports a status on PRs.
- Guard `build-and-push` with `if: github.event_name != 'pull_request'` so a PR runs **only** the audit — not image build/push or deploy (the `deploy-*` jobs are additionally gated on master/dispatch and `need` build-and-push, so they skip too).
- Also carried along from `dev`: `docs(agents): document board auto-linking protocol`.

---

## Why was this change needed?

The workflow only triggered on `push` (master/dev) and `workflow_dispatch`, never `pull_request`. With "Dependency Audit" set as a **required** check in master branch protection, PRs sat at *"waiting for status to be reported"* forever — never failing, never finishing. We had been unblocking PRs by removing the check from master protection, which leaves master without an audit gate. This makes the check report on PRs so the gate can be restored.

---

## How was it tested?

- `vitest run` passes locally (~2s, exits clean) — ruled out a hung test process.
- `bash scripts/security-check.sh` passed: forbidden-file check, secret scan, and `npm audit --audit-level=high` clean on both backend and frontend.
- YAML validated; the push to `dev` produced a healthy CI/CD run.
- **This PR is the live test:** with the new `pull_request` trigger, the Dependency Audit check should now run and report on this PR.

---

## Checklist

- [x] Code works locally (tests pass; no app/runtime change in this PR)
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] **This PR touches `.github/workflows/ci-cd.yml`** — called out here per AGENTS.md §4

---

> ⚠️ Merging to `master` auto-deploys to the Azure VM. Opened as **draft**; mark ready / merge once the Dependency Audit check reports green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
