### PR TITLE
feat(deploy): Postgres tier + blue/green deploy fix for three-VM path

### DIFF
--- a/deploy/README-blue-green.md
+++ b/deploy/README-blue-green.md
@@ -99,6 +99,36 @@ environment variables are set:
 
 For the three-VM workflow, CI maps `DATABASE_PRIVATE_IP` to `POSTGRES_HOST`.
 
+## Database Setup (one-time)
+
+Postgres runs as a single container on the **database VM** via
+[`postgres.yml`](./blue-green/postgres.yml). This is a **one-time, stateful**
+setup — data lives in the named volume `cookbook_pgdata`
+(`/var/lib/postgresql/data`) and survives container restarts and VM reboots
+(`restart: unless-stopped`). It is intentionally **not** part of the per-deploy
+CI flow, so an app deploy never risks the database.
+
+The app creates its schema and seeds itself on first boot
+([`backend/db/schema.js`](../backend/db/schema.js) runs `CREATE TABLE IF NOT
+EXISTS` + seeds when empty), so **no manual schema load or migration is
+needed** — only an empty database and a user that owns it.
+
+Credentials are read from a `chmod 600` env file on the VM that must match the
+GitHub secrets (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`). The
+compose file never hard-codes the password.
+
+Bring it up on the database VM (reached via the nginx VM as a jump host):
+
+```bash
+cd ~/app/blue-green
+# postgres.env contains POSTGRES_DB / POSTGRES_USER / POSTGRES_PASSWORD (chmod 600)
+sudo docker compose --env-file postgres.env -f postgres.yml up -d
+sudo docker exec cookbook-postgres pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+```
+
+The Azure NSG only allows port `5432` from the backend VM, so publishing the
+port on the database VM is not publicly reachable.
+
 ## Migration Rule
 
 Blue/green means old and new backend versions can run at the same time. Any

--- a/deploy/blue-green/deploy-blue-green.sh
+++ b/deploy/blue-green/deploy-blue-green.sh
@@ -114,6 +114,11 @@ for attempt in $(seq 1 "$HEALTH_RETRIES"); do
       printf "UPDATED_AT=%s\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     } > "$tmp_file"
     mv "$tmp_file" "$ACTIVE_ENV_FILE"
+    # Written under sudo (root). Hand ownership back to the SSH user (owner of
+    # the deploy dir) so the CI sync/switch steps can scp this file both ways on
+    # every deploy, not just the first. Contains no secrets.
+    chown --reference="$SCRIPT_DIR" "$ACTIVE_ENV_FILE" 2>/dev/null || true
+    chmod 0644 "$ACTIVE_ENV_FILE"
     echo "backend-$TARGET_COLOR is healthy on $TARGET_BACKEND_HOST"
     exit 0
   fi

--- a/deploy/blue-green/postgres.yml
+++ b/deploy/blue-green/postgres.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: cookbook-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      # Published on the database VM so the backend VM can reach it at
+      # ${DATABASE_PRIVATE_IP}:5432. The Azure NSG restricts source to the
+      # backend VM only, so 0.0.0.0 here is not publicly reachable.
+      - "5432:5432"
+    volumes:
+      - cookbook_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  cookbook_pgdata:
+    driver: local


### PR DESCRIPTION
# Pull Request

## Linked issues
Closes #

> No single tracked issue maps cleanly to this work (the deployment-strategy
> #43 and rollback #47 issues were already closed by #77). This PR is the
> operational completion of the three-VM path: standing up the Postgres tier
> and fixing a deploy-script bug found while doing so.

---

## What was done?
Completes the three-VM blue/green deploy path (the DB tier was provisioned but Postgres wasn't running, and the deploy failed at the final step).

- **`deploy/blue-green/postgres.yml`** — Postgres service for the database VM. One-time, stateful: data in the named volume `cookbook_pgdata`, `restart: unless-stopped`, credentials from a `chmod 600` env file matching the GitHub secrets (never hard-coded). Not part of the per-deploy CI flow.
- **`deploy/blue-green/deploy-blue-green.sh`** — fix: `active-color.env` was written root-owned (mode 600) because the script runs under `sudo`, so the CI "switch nginx" step couldn't `scp` it back (and repeated deploys couldn't overwrite it). Now `chown`'d to the deploy-dir owner + `chmod 0644` after the atomic move. The file holds no secrets.
- **`deploy/README-blue-green.md`** — documents the one-time Postgres setup.

---

## Why was this change needed?
`DEPLOY_MODE=three-vms` but nothing started Postgres on the database VM, and the blue/green deploy failed at "switch nginx" on a file-permission bug. Without these, every three-VM deploy fails.

---

## How was it tested?
- Triggered a `three-vms` deploy via `workflow_dispatch` on this branch → **green** (build + deploy-three-VM-blue-green all pass).
- End-to-end: `GET http://<nginx>/api/recipe/recipes/` returns the 9 seeded recipes **served from Postgres**; frontend returns HTTP 200; `backend-green` healthy on :3002.
- `bash scripts/security-check.sh` → **PASSED**.

---

## Checklist

- [x] Code works locally (Docker compose `dev` profile comes up clean) — *not re-run; change is deploy-only and was verified directly on the three-VM stack*
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above

> Scope note: changes are limited to `deploy/blue-green/**` + `deploy/README-blue-green.md`. **No** changes to `.github/workflows/`, `infrastructure/`, or any `Dockerfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
