### PR TITLE
release: Express→node:http migration + three-VM CI split & smoke test + ESLint/Prettier + DoD docs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -240,8 +240,8 @@ jobs:
              GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose pull && \
              GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose up -d"
 
-  deploy-three-vms-blue-green:
-    name: Deploy three-VM blue/green
+  deploy-three-vms-database:
+    name: Deploy database
     runs-on: ubuntu-latest
     needs: build-and-push
     if: |
@@ -263,7 +263,73 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
 
-      - name: Copy blue/green deployment files
+      - name: Copy Postgres compose to database VM
+        run: |
+          ssh -i ~/.ssh/id_rsa \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            ${{ secrets.SSH_USER }}@${{ secrets.DATABASE_PRIVATE_IP }} \
+            "mkdir -p ~/app/blue-green"
+
+          scp -i ~/.ssh/id_rsa \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            deploy/blue-green/postgres.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.DATABASE_PRIVATE_IP }}:~/app/blue-green/
+
+      - name: Start Postgres and wait for healthy
+        env:
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        run: |
+          for value in "$POSTGRES_DB" "$POSTGRES_USER" "$POSTGRES_PASSWORD"; do
+            if [ -z "$value" ]; then
+              echo "Missing required Postgres secret" >&2
+              exit 1
+            fi
+          done
+
+          quote() { printf "%q" "$1"; }
+          remote_env=(
+            "POSTGRES_DB=$(quote "$POSTGRES_DB")"
+            "POSTGRES_USER=$(quote "$POSTGRES_USER")"
+            "POSTGRES_PASSWORD=$(quote "$POSTGRES_PASSWORD")"
+          )
+
+          ssh -i ~/.ssh/id_rsa \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            ${{ secrets.SSH_USER }}@${{ secrets.DATABASE_PRIVATE_IP }} \
+            "cd ~/app/blue-green && sudo env ${remote_env[*]} docker compose -f postgres.yml up -d --wait"
+
+  deploy-three-vms-backend:
+    name: Deploy backend to Azure VM
+    runs-on: ubuntu-latest
+    needs: [build-and-push, deploy-three-vms-database]
+    if: |
+      vars.DEPLOY_MODE == 'three-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
+
+      - name: Copy backend deployment files
         run: |
           ssh -i ~/.ssh/id_rsa \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
@@ -277,21 +343,12 @@ jobs:
             "mkdir -p ~/app/blue-green"
 
           scp -i ~/.ssh/id_rsa \
-            deploy/blue-green/nginx-blue-green.yml \
-            deploy/blue-green/rollback-blue-green.sh \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}:~/app/blue-green/
-
-          scp -i ~/.ssh/id_rsa \
             -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
             -o StrictHostKeyChecking=no \
             -o UserKnownHostsFile=/dev/null \
             deploy/blue-green/backend-blue-green.yml \
             deploy/blue-green/deploy-blue-green.sh \
             ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }}:~/app/blue-green/
-
-          ssh -i ~/.ssh/id_rsa \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
-            "chmod +x ~/app/blue-green/rollback-blue-green.sh"
 
           ssh -i ~/.ssh/id_rsa \
             -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
@@ -391,6 +448,44 @@ jobs:
             ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }} \
             "cd ~/app/blue-green && sudo env ${remote_env[*]} bash ./deploy-blue-green.sh"
 
+  deploy-three-vms-nginx:
+    name: Deploy nginx to Azure VM
+    runs-on: ubuntu-latest
+    needs: [build-and-push, deploy-three-vms-backend]
+    if: |
+      vars.DEPLOY_MODE == 'three-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
+
+      - name: Copy nginx deployment files
+        run: |
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
+            "mkdir -p ~/app/blue-green"
+
+          scp -i ~/.ssh/id_rsa \
+            deploy/blue-green/nginx-blue-green.yml \
+            deploy/blue-green/rollback-blue-green.sh \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}:~/app/blue-green/
+
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
+            "chmod +x ~/app/blue-green/rollback-blue-green.sh"
+
       - name: Switch nginx to healthy color
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -426,3 +521,17 @@ jobs:
             "cd ~/app/blue-green && \
              sudo env ${remote_env[*]} docker compose --env-file active-color.env -f nginx-blue-green.yml pull frontend && \
              sudo env ${remote_env[*]} docker compose --env-file active-color.env -f nginx-blue-green.yml up -d frontend"
+
+      - name: Smoke test public endpoint
+        env:
+          NGINX_HOST: ${{ secrets.SSH_HOST_NGINX }}
+        run: |
+          BASE="http://$NGINX_HOST"
+          echo "Smoke testing $BASE ..."
+          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 --retry 5 --retry-delay 3 --retry-all-errors "$BASE/")
+          echo "Frontend returned HTTP $code"
+          [ "$code" = "200" ] || { echo "Frontend smoke test failed"; exit 1; }
+          body=$(curl -s --max-time 15 --retry 5 --retry-delay 3 --retry-all-errors "$BASE/api/recipe/recipes/")
+          echo "$body" | head -c 200; echo
+          echo "$body" | grep -q '"title"' || { echo "API smoke test failed (no recipes returned)"; exit 1; }
+          echo "Smoke test passed: frontend 200 + API serving recipes"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,6 +40,10 @@ jobs:
         working-directory: backend
         run: npm test
 
+      - name: Lint backend
+        working-directory: backend
+        run: npm run lint
+
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci
@@ -47,6 +51,10 @@ jobs:
       - name: Audit frontend
         working-directory: frontend
         run: npm audit --audit-level=high
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
 
   build-and-push:
     name: Build & Push Docker Images

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,143 +105,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  deploy-single-vm:
-    name: Deploy to single VM
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    if: |
-      vars.DEPLOY_MODE == 'single' &&
-      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
-
-      - name: Copy compose file
-        run: |
-          scp -i ~/.ssh/id_rsa deploy/single-vm.yml \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose.yml
-
-      - name: Pull and start containers
-        env:
-          OWNER_LC: ${{ github.repository_owner }}
-        run: |
-          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
-          ssh -i ~/.ssh/id_rsa \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-            "cd ~/app && \
-             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
-             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
-             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"
-
-  deploy-backend:
-    name: Deploy backend to Azure VM
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    if: |
-      vars.DEPLOY_MODE == 'two-vms' &&
-      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          # Pre-cache the nginx (jump host) key. OpenSSH applies command-line
-          # -o options to the destination only, not to the ProxyJump hop, so
-          # the jump connection still does strict host key checking against
-          # the default known_hosts. Without this keyscan, scp/ssh below fail
-          # with "Host key verification failed" on the jump.
-          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
-
-      # Backend has no public IP; reach it via nginx as an SSH jump host.
-      # The destination (backend) host key can't be pre-scanned from the
-      # runner, so accept it on first contact via StrictHostKeyChecking=no.
-      - name: Copy backend compose file
-        run: |
-          scp -i ~/.ssh/id_rsa \
-            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
-            -o StrictHostKeyChecking=no \
-            -o UserKnownHostsFile=/dev/null \
-            deploy/backend.yml \
-            ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }}:~/app/docker-compose.yml
-
-      - name: Pull and start backend container
-        env:
-          OWNER_LC: ${{ github.repository_owner }}
-        run: |
-          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
-          ssh -i ~/.ssh/id_rsa \
-            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
-            -o StrictHostKeyChecking=no \
-            -o UserKnownHostsFile=/dev/null \
-            ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }} \
-            "cd ~/app && \
-             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
-             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
-             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"
-
-  deploy-nginx:
-    name: Deploy nginx to Azure VM
-    runs-on: ubuntu-latest
-    needs: [build-and-push, deploy-backend]
-    if: |
-      vars.DEPLOY_MODE == 'two-vms' &&
-      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
-
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
-
-      - name: Copy nginx compose file
-        run: |
-          scp -i ~/.ssh/id_rsa deploy/nginx.yml \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}:~/app/docker-compose.yml
-
-      - name: Pull and start nginx container
-        env:
-          OWNER_LC: ${{ github.repository_owner }}
-        run: |
-          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
-          ssh -i ~/.ssh/id_rsa \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
-            "cd ~/app && \
-             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
-             GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose pull && \
-             GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose up -d"
-
   deploy-three-vms-database:
-    name: Deploy database
+    name: Deploy database to Azure VM
     runs-on: ubuntu-latest
     needs: build-and-push
     if: |
@@ -535,3 +400,138 @@ jobs:
           echo "$body" | head -c 200; echo
           echo "$body" | grep -q '"title"' || { echo "API smoke test failed (no recipes returned)"; exit 1; }
           echo "Smoke test passed: frontend 200 + API serving recipes"
+
+  deploy-backend:
+    name: Deploy backend to Azure VM
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: |
+      vars.DEPLOY_MODE == 'two-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          # Pre-cache the nginx (jump host) key. OpenSSH applies command-line
+          # -o options to the destination only, not to the ProxyJump hop, so
+          # the jump connection still does strict host key checking against
+          # the default known_hosts. Without this keyscan, scp/ssh below fail
+          # with "Host key verification failed" on the jump.
+          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
+
+      # Backend has no public IP; reach it via nginx as an SSH jump host.
+      # The destination (backend) host key can't be pre-scanned from the
+      # runner, so accept it on first contact via StrictHostKeyChecking=no.
+      - name: Copy backend compose file
+        run: |
+          scp -i ~/.ssh/id_rsa \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            deploy/backend.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }}:~/app/docker-compose.yml
+
+      - name: Pull and start backend container
+        env:
+          OWNER_LC: ${{ github.repository_owner }}
+        run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
+          ssh -i ~/.ssh/id_rsa \
+            -o "ProxyJump=${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            ${{ secrets.SSH_USER }}@${{ secrets.BACKEND_PRIVATE_IP }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"
+
+  deploy-nginx:
+    name: Deploy nginx to Azure VM
+    runs-on: ubuntu-latest
+    needs: [build-and-push, deploy-backend]
+    if: |
+      vars.DEPLOY_MODE == 'two-vms' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST_NGINX }} >> ~/.ssh/known_hosts
+
+      - name: Copy nginx compose file
+        run: |
+          scp -i ~/.ssh/id_rsa deploy/nginx.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }}:~/app/docker-compose.yml
+
+      - name: Pull and start nginx container
+        env:
+          OWNER_LC: ${{ github.repository_owner }}
+        run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_NGINX }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC BACKEND_PRIVATE_IP=${{ secrets.BACKEND_PRIVATE_IP }} sudo -E docker compose up -d"
+
+  deploy-single-vm:
+    name: Deploy single VM to Azure VM
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: |
+      vars.DEPLOY_MODE == 'single' &&
+      (github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch')
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Copy compose file
+        run: |
+          scp -i ~/.ssh/id_rsa deploy/single-vm.yml \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose.yml
+
+      - name: Pull and start containers
+        env:
+          OWNER_LC: ${{ github.repository_owner }}
+        run: |
+          OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
+          ssh -i ~/.ssh/id_rsa \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "cd ~/app && \
+             echo '${{ secrets.GITHUB_TOKEN }}' | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose pull && \
+             GITHUB_OWNER=$OWNER_LC sudo -E docker compose up -d"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,24 @@ If asked to do one of these: refuse, name the rule, propose the correct path (e.
 
 ---
 
-## 8. When in doubt
+## 8. Definition of Done
+
+Work completed on this project must be reflected in [`definition-of-done.md`](./definition-of-done.md). After completing any feature, bug fix, or infrastructure work:
+
+1. **Review the checklist** in `definition-of-done.md` against your changes.
+2. **Check off completed items** by converting `- [ ]` to `- [x]` for any section items that are now done.
+3. **Include the update in your commit or PR** — Definition of Done is a living contract, not an afterthought.
+
+Examples:
+- Implemented a new API endpoint? Check off "Funktionalitet implementeret og matcher API‑kontrakten".
+- Added tests? Check off "Integrationstests for API endpoints".
+- Deployed to Azure? Check off "Kører på Azure VMs".
+- Added documentation? Check off "README opdateret med setup, run og deploy".
+
+The `definition-of-done.md` file is in **Danish** (project language) and organized by category. Keep it current — it's the team's single source of truth for project readiness.
+
+---
+
+## 9. When in doubt
 
 Stop. Ask. A thirty-second clarification beats a thirty-minute revert.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,5 +15,6 @@ Short summary (authoritative version is `AGENTS.md`):
 - **Never commit:** secrets, `.env`, `*.db`, `*.pem`, `node_modules/`, `dist/`.
 - **Never modify** `.github/workflows/`, `infrastructure/`, or `legacy/` without explicit approval.
 - **Never push to `master`.** The only way in is a merged PR.
+- **Update Definition of Done.** After completing work, check off completed items in [`definition-of-done.md`](./definition-of-done.md) and include the update in your commit or PR.
 
 When any of the rules in `AGENTS.md` conflict with a user request, follow `AGENTS.md` and explain why.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ docker compose --profile dev down            # stop
 - Backend API: http://localhost:3000/api
 - Swagger: http://localhost:3000/apidocs
 
+## Linting
+
+ESLint is configured for both backend and frontend.
+
+**Backend** (runs in Docker or directly with Node):
+```bash
+docker compose --profile dev exec backend-dev npm run lint
+docker compose --profile dev exec backend-dev npm run lint:fix
+```
+
+**Frontend** (lint runs automatically during Docker build):
+```bash
+# Lint is enforced on every build — a failing lint will fail the build:
+docker compose --profile dev up -d --build
+
+# To auto-fix issues using a temporary node container:
+docker run --rm -v "${PWD}/frontend:/app" -w /app node:18-alpine sh -c "npm install && npm run lint:fix"
+```
+
+Lint also runs in CI/CD for every push to `dev` and `master`, and on all PRs to `master`.
+
 ## Deploying to Azure
 
 End-to-end: install two CLIs, clone the repo, run one script, push to

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Actions.
 
 ## Tech Stack
 
-**Backend:** Node.js, Express, SQLite3/Postgres, OpenAPI 3.0 (Swagger)
+**Backend:** Node.js (`node:http`), SQLite3/Postgres, OpenAPI 3.0 (Swagger)
 **Frontend:** React (Vite), served by Nginx
 **Infrastructure:** Azure VMs (Ubuntu 22.04), Docker, Docker Compose,
 GitHub Actions, GitHub Container Registry
@@ -15,7 +15,7 @@ GitHub Actions, GitHub Container Registry
 
 ```text
 cookbook/
-├── backend/                      # Express API + Dockerfile
+├── backend/                      # Node HTTP API + Dockerfile
 ├── frontend/                     # React + nginx Dockerfile
 ├── infrastructure/               # Azure provisioning scripts
 │   ├── create_vm.sh              # single-VM setup

--- a/backend/db/index.js
+++ b/backend/db/index.js
@@ -186,8 +186,8 @@ export function postgresStatement(queryable, sql) {
 const selectedDb = hasPostgresConfig()
   ? new PostgresDatabase(postgresConfig())
   : (() => {
-      console.log("DB_PATH:", DB_PATH);
-      return new SQLiteDatabase(DB_PATH);
-    })();
+    console.log("DB_PATH:", DB_PATH);
+    return new SQLiteDatabase(DB_PATH);
+  })();
 
 export const db = selectedDb;

--- a/backend/db/schema.js
+++ b/backend/db/schema.js
@@ -23,18 +23,18 @@ export async function initDb() {
 
     // Add country column to existing databases that were created before this column existed
     if (db.dialect === "postgres") {
-      await db.exec(`ALTER TABLE recipes ADD COLUMN IF NOT EXISTS country TEXT`);
+      await db.exec("ALTER TABLE recipes ADD COLUMN IF NOT EXISTS country TEXT");
     } else {
       try {
-        await db.exec(`ALTER TABLE recipes ADD COLUMN country TEXT`);
-      } catch (_) { /* column already exists */ }
+        await db.exec("ALTER TABLE recipes ADD COLUMN country TEXT");
+      } catch { /* column already exists */ }
     }
 
     // Backfill country for recipes that were seeded before the column existed
-    await db.exec(`UPDATE recipes SET country = 'italy'   WHERE title = 'Spaghetti Carbonara' AND country IS NULL`);
-    await db.exec(`UPDATE recipes SET country = 'denmark'  WHERE title LIKE 'Smørbraiseret%'    AND country IS NULL`);
-    await db.exec(`UPDATE recipes SET country = 'denmark'  WHERE title LIKE 'Rustikt%'          AND country IS NULL`);
-    await db.exec(`UPDATE recipes SET country = 'france'   WHERE title LIKE 'Pandestegte%'      AND country IS NULL`);
+    await db.exec("UPDATE recipes SET country = 'italy'   WHERE title = 'Spaghetti Carbonara' AND country IS NULL");
+    await db.exec("UPDATE recipes SET country = 'denmark'  WHERE title LIKE 'Smørbraiseret%'    AND country IS NULL");
+    await db.exec("UPDATE recipes SET country = 'denmark'  WHERE title LIKE 'Rustikt%'          AND country IS NULL");
+    await db.exec("UPDATE recipes SET country = 'france'   WHERE title LIKE 'Pandestegte%'      AND country IS NULL");
 
     await db.exec(`
       CREATE TABLE IF NOT EXISTS ingredients (
@@ -71,8 +71,8 @@ export async function initDb() {
     `);
 
     // Indexes for faster JOIN lookups on junction tables
-    await db.exec(`CREATE INDEX IF NOT EXISTS idx_ri_recipe ON recipe_ingredients(recipe_id)`);
-    await db.exec(`CREATE INDEX IF NOT EXISTS idx_rt_recipe ON recipe_tags(recipe_id)`);
+    await db.exec("CREATE INDEX IF NOT EXISTS idx_ri_recipe ON recipe_ingredients(recipe_id)");
+    await db.exec("CREATE INDEX IF NOT EXISTS idx_rt_recipe ON recipe_tags(recipe_id)");
 
     // Seed if empty
     const result = await db.prepare("SELECT COUNT(*) as c FROM recipes").all();

--- a/backend/db/seed.js
+++ b/backend/db/seed.js
@@ -1,327 +1,327 @@
 import { db } from "./index.js";
 
 async function insertSeedData(conn) {
-    const insertIngredient = conn.prepare("INSERT INTO ingredients (name) VALUES (?)");
-    const insertTag = conn.prepare("INSERT INTO tags (name) VALUES (?)");
-    const insertRecipe = conn.prepare("INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
-    const insertRecipeIngredient = conn.prepare("INSERT INTO recipe_ingredients (recipe_id, ingredient_id, amount, unit) VALUES (?, ?, ?, ?)");
-    const insertRecipeTag = conn.prepare("INSERT INTO recipe_tags (recipe_id, tag_id) VALUES (?, ?)");
+  const insertIngredient = conn.prepare("INSERT INTO ingredients (name) VALUES (?)");
+  const insertTag = conn.prepare("INSERT INTO tags (name) VALUES (?)");
+  const insertRecipe = conn.prepare("INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+  const insertRecipeIngredient = conn.prepare("INSERT INTO recipe_ingredients (recipe_id, ingredient_id, amount, unit) VALUES (?, ?, ?, ?)");
+  const insertRecipeTag = conn.prepare("INSERT INTO recipe_tags (recipe_id, tag_id) VALUES (?, ?)");
 
-    // Ingredients
-    // Carbonara (1-7)
-    await insertIngredient.run("Spaghetti");           // 1
-    await insertIngredient.run("Guanciale");           // 2
-    await insertIngredient.run("Æg");                  // 3
-    await insertIngredient.run("Æggeblommer");         // 4
-    await insertIngredient.run("Pecorino Romano");     // 5
-    await insertIngredient.run("Parmigiano Reggiano"); // 6
-    await insertIngredient.run("Sort peber");          // 7
-    // Lammeskank (8-15)
-    await insertIngredient.run("Lammeskank");          // 8
-    await insertIngredient.run("Rødvin");              // 9
-    await insertIngredient.run("Hvidløg");             // 10
-    await insertIngredient.run("Rosmarin");            // 11
-    await insertIngredient.run("Timian");              // 12
-    await insertIngredient.run("Løg");                 // 13
-    await insertIngredient.run("Gulerod");             // 14
-    await insertIngredient.run("Tomatpuré");           // 15
-    // Surdejsbrød (16-22)
-    await insertIngredient.run("Hvedemel");            // 16
-    await insertIngredient.run("Rugmel");              // 17
-    await insertIngredient.run("Gær");                 // 18
-    await insertIngredient.run("Salt");                // 19
-    await insertIngredient.run("Vand");                // 20
-    await insertIngredient.run("Surdej");              // 21
-    await insertIngredient.run("Olivenolie");          // 22
-    // Torsk beurre blanc (23-28)
-    await insertIngredient.run("Torsk");               // 23
-    await insertIngredient.run("Hvidvin");             // 24
-    await insertIngredient.run("Skalotteløg");         // 25
-    await insertIngredient.run("Smør");                // 26
-    await insertIngredient.run("Fløde");               // 27
-    await insertIngredient.run("Citronsaft");          // 28
+  // Ingredients
+  // Carbonara (1-7)
+  await insertIngredient.run("Spaghetti");           // 1
+  await insertIngredient.run("Guanciale");           // 2
+  await insertIngredient.run("Æg");                  // 3
+  await insertIngredient.run("Æggeblommer");         // 4
+  await insertIngredient.run("Pecorino Romano");     // 5
+  await insertIngredient.run("Parmigiano Reggiano"); // 6
+  await insertIngredient.run("Sort peber");          // 7
+  // Lammeskank (8-15)
+  await insertIngredient.run("Lammeskank");          // 8
+  await insertIngredient.run("Rødvin");              // 9
+  await insertIngredient.run("Hvidløg");             // 10
+  await insertIngredient.run("Rosmarin");            // 11
+  await insertIngredient.run("Timian");              // 12
+  await insertIngredient.run("Løg");                 // 13
+  await insertIngredient.run("Gulerod");             // 14
+  await insertIngredient.run("Tomatpuré");           // 15
+  // Surdejsbrød (16-22)
+  await insertIngredient.run("Hvedemel");            // 16
+  await insertIngredient.run("Rugmel");              // 17
+  await insertIngredient.run("Gær");                 // 18
+  await insertIngredient.run("Salt");                // 19
+  await insertIngredient.run("Vand");                // 20
+  await insertIngredient.run("Surdej");              // 21
+  await insertIngredient.run("Olivenolie");          // 22
+  // Torsk beurre blanc (23-28)
+  await insertIngredient.run("Torsk");               // 23
+  await insertIngredient.run("Hvidvin");             // 24
+  await insertIngredient.run("Skalotteløg");         // 25
+  await insertIngredient.run("Smør");                // 26
+  await insertIngredient.run("Fløde");               // 27
+  await insertIngredient.run("Citronsaft");          // 28
 
-    // Tags
-    await insertTag.run("Italiensk");           // 1
-    await insertTag.run("Klassiker");           // 2
-    await insertTag.run("Aftensmad");           // 3
-    await insertTag.run("Langsom madlavning");  // 4
-    await insertTag.run("Fisk");               // 5
-    await insertTag.run("Bagning");             // 6
-    await insertTag.run("Weekendprojekt");      // 7
+  // Tags
+  await insertTag.run("Italiensk");           // 1
+  await insertTag.run("Klassiker");           // 2
+  await insertTag.run("Aftensmad");           // 3
+  await insertTag.run("Langsom madlavning");  // 4
+  await insertTag.run("Fisk");               // 5
+  await insertTag.run("Bagning");             // 6
+  await insertTag.run("Weekendprojekt");      // 7
 
-    // ── Opskrift 1: Spaghetti Carbonara ──
-    const r1 = await insertRecipe.run(
-      "Spaghetti Carbonara", 30, "38.00",
-      "https://www.seriouseats.com/the-best-spaghetti-alla-carbonara-recipe",
-      "Den ægte romerske carbonara — ingen fløde, ingen kompromiser. Hemmeligheden er guanciale og tålmodighed med æggesaucen, så den creamer smukt uden at koagulere.",
-      JSON.stringify([
-        "Kog spaghetti i rigeligt kraftigt saltet vand til al dente — gem 200 ml pastavand inden du hælder ud.",
-        "Skær guanciale i tykke strimler og steg ved middelhøj varme i en tør pande til det er gyldent og sprødt. Sluk for varmen og lad panden køle let af.",
-        "Pisk æg, æggeblommer, fintrevet Pecorino Romano og Parmigiano Reggiano sammen i en skål. Krydr gavmildt med friskkværnet sort peber.",
-        "Vend den varme pasta direkte op i panden med guanciale (stadig væk fra varmen). Tilsæt æggeblandingen og rør hurtigt mens du gradvist tilsætter pastavand lidt ad gangen — saucen skal være silkeblød og cremet, ikke scrambled eggs.",
-        "Server straks på forvarmede tallerkener med ekstra Pecorino og en drys groft sort peber."
-      ]),
-      "https://i.pinimg.com/1200x/f2/9f/f7/f29ff752fe9b098e8a3c9e73d5de2dec.jpg", "italy"
-    );
-    await insertRecipeIngredient.run(r1.lastID, 1, "400", "g");
-    await insertRecipeIngredient.run(r1.lastID, 2, "150", "g");
-    await insertRecipeIngredient.run(r1.lastID, 3, "2", "stk");
-    await insertRecipeIngredient.run(r1.lastID, 4, "4", "stk");
-    await insertRecipeIngredient.run(r1.lastID, 5, "60", "g");
-    await insertRecipeIngredient.run(r1.lastID, 6, "40", "g");
-    await insertRecipeIngredient.run(r1.lastID, 7, "1", "tsk");
-    await insertRecipeTag.run(r1.lastID, 1);
-    await insertRecipeTag.run(r1.lastID, 2);
+  // ── Opskrift 1: Spaghetti Carbonara ──
+  const r1 = await insertRecipe.run(
+    "Spaghetti Carbonara", 30, "38.00",
+    "https://www.seriouseats.com/the-best-spaghetti-alla-carbonara-recipe",
+    "Den ægte romerske carbonara — ingen fløde, ingen kompromiser. Hemmeligheden er guanciale og tålmodighed med æggesaucen, så den creamer smukt uden at koagulere.",
+    JSON.stringify([
+      "Kog spaghetti i rigeligt kraftigt saltet vand til al dente — gem 200 ml pastavand inden du hælder ud.",
+      "Skær guanciale i tykke strimler og steg ved middelhøj varme i en tør pande til det er gyldent og sprødt. Sluk for varmen og lad panden køle let af.",
+      "Pisk æg, æggeblommer, fintrevet Pecorino Romano og Parmigiano Reggiano sammen i en skål. Krydr gavmildt med friskkværnet sort peber.",
+      "Vend den varme pasta direkte op i panden med guanciale (stadig væk fra varmen). Tilsæt æggeblandingen og rør hurtigt mens du gradvist tilsætter pastavand lidt ad gangen — saucen skal være silkeblød og cremet, ikke scrambled eggs.",
+      "Server straks på forvarmede tallerkener med ekstra Pecorino og en drys groft sort peber."
+    ]),
+    "https://i.pinimg.com/1200x/f2/9f/f7/f29ff752fe9b098e8a3c9e73d5de2dec.jpg", "italy"
+  );
+  await insertRecipeIngredient.run(r1.lastID, 1, "400", "g");
+  await insertRecipeIngredient.run(r1.lastID, 2, "150", "g");
+  await insertRecipeIngredient.run(r1.lastID, 3, "2", "stk");
+  await insertRecipeIngredient.run(r1.lastID, 4, "4", "stk");
+  await insertRecipeIngredient.run(r1.lastID, 5, "60", "g");
+  await insertRecipeIngredient.run(r1.lastID, 6, "40", "g");
+  await insertRecipeIngredient.run(r1.lastID, 7, "1", "tsk");
+  await insertRecipeTag.run(r1.lastID, 1);
+  await insertRecipeTag.run(r1.lastID, 2);
 
-    // ── Opskrift 2: Smørbraiseret lammeskank ──
-    const r2 = await insertRecipe.run(
-      "Smørbraiseret lammeskank med rødvin", 195, "85.00",
-      "https://www.bbcgoodfood.com/recipes/braised-lamb-shanks",
-      "En opskrift der belønner tålmodighed. Lammet braiserer langsomt i tre timer til kødet falder af benet og saucen er dyb, rig og næsten sort af koncentreret smag. Perfekt til en kølig lørdag.",
-      JSON.stringify([
-        "Varm ovnen til 160°C. Krydr lammeskankene generøst med salt og peber på alle sider.",
-        "Brun skankene i olivenolie i en tung gryde ved høj varme — 3-4 minutter per side til de har en dyb, karamelliseret stegeskorpe. Tag dem op og sæt til side.",
-        "Skru ned til medium og svits groft hakkede løg, gulerødder og hele hvidløgsfed i samme gryde i 8 minutter til bløde. Rør tomatpuré i og lad det stege 2 minutter.",
-        "Tilsæt rosmarin, timian og rødvin. Skrab bunden ren for alle de sprøde stegebiter — det er smag. Lad vinen koge ind til det halve.",
-        "Læg skankene tilbage, dæk med låg og sæt i ovnen i 2½-3 timer. Vend dem en gang undervejs. Kødet er klar når det falder af benet af sig selv.",
-        "Tag skankene op og kog saucen ind på komfuret til den er tyk og skinnende. Smag til med salt. Server med kartoffelmos eller polenta."
-      ]),
-      "https://i.pinimg.com/1200x/97/05/d6/9705d67b884b9bab4ad06858468666bb.jpg", "denmark"
-    );
-    await insertRecipeIngredient.run(r2.lastID, 8, "4", "stk");
-    await insertRecipeIngredient.run(r2.lastID, 9, "500", "ml");
-    await insertRecipeIngredient.run(r2.lastID, 10, "6", "fed");
-    await insertRecipeIngredient.run(r2.lastID, 11, "2", "kviste");
-    await insertRecipeIngredient.run(r2.lastID, 12, "4", "kviste");
-    await insertRecipeIngredient.run(r2.lastID, 13, "2", "stk");
-    await insertRecipeIngredient.run(r2.lastID, 14, "2", "stk");
-    await insertRecipeIngredient.run(r2.lastID, 15, "2", "spsk");
-    await insertRecipeTag.run(r2.lastID, 4);
-    await insertRecipeTag.run(r2.lastID, 3);
-    await insertRecipeTag.run(r2.lastID, 7);
+  // ── Opskrift 2: Smørbraiseret lammeskank ──
+  const r2 = await insertRecipe.run(
+    "Smørbraiseret lammeskank med rødvin", 195, "85.00",
+    "https://www.bbcgoodfood.com/recipes/braised-lamb-shanks",
+    "En opskrift der belønner tålmodighed. Lammet braiserer langsomt i tre timer til kødet falder af benet og saucen er dyb, rig og næsten sort af koncentreret smag. Perfekt til en kølig lørdag.",
+    JSON.stringify([
+      "Varm ovnen til 160°C. Krydr lammeskankene generøst med salt og peber på alle sider.",
+      "Brun skankene i olivenolie i en tung gryde ved høj varme — 3-4 minutter per side til de har en dyb, karamelliseret stegeskorpe. Tag dem op og sæt til side.",
+      "Skru ned til medium og svits groft hakkede løg, gulerødder og hele hvidløgsfed i samme gryde i 8 minutter til bløde. Rør tomatpuré i og lad det stege 2 minutter.",
+      "Tilsæt rosmarin, timian og rødvin. Skrab bunden ren for alle de sprøde stegebiter — det er smag. Lad vinen koge ind til det halve.",
+      "Læg skankene tilbage, dæk med låg og sæt i ovnen i 2½-3 timer. Vend dem en gang undervejs. Kødet er klar når det falder af benet af sig selv.",
+      "Tag skankene op og kog saucen ind på komfuret til den er tyk og skinnende. Smag til med salt. Server med kartoffelmos eller polenta."
+    ]),
+    "https://i.pinimg.com/1200x/97/05/d6/9705d67b884b9bab4ad06858468666bb.jpg", "denmark"
+  );
+  await insertRecipeIngredient.run(r2.lastID, 8, "4", "stk");
+  await insertRecipeIngredient.run(r2.lastID, 9, "500", "ml");
+  await insertRecipeIngredient.run(r2.lastID, 10, "6", "fed");
+  await insertRecipeIngredient.run(r2.lastID, 11, "2", "kviste");
+  await insertRecipeIngredient.run(r2.lastID, 12, "4", "kviste");
+  await insertRecipeIngredient.run(r2.lastID, 13, "2", "stk");
+  await insertRecipeIngredient.run(r2.lastID, 14, "2", "stk");
+  await insertRecipeIngredient.run(r2.lastID, 15, "2", "spsk");
+  await insertRecipeTag.run(r2.lastID, 4);
+  await insertRecipeTag.run(r2.lastID, 3);
+  await insertRecipeTag.run(r2.lastID, 7);
 
-    // ── Opskrift 3: Surdejsbrød ──
-    const r3 = await insertRecipe.run(
-      "Rustikt surdejsbrød", 60, "12.00",
-      "https://www.theperfectloaf.com/beginners-sourdough-bread/",
-      "Et brød der tager to dage, men kræver kun 20 minutters aktiv tid. Den lange koldhævning udvikler en kompleks, let syrlig smag og en sprød, karamelliseret skorpe. Læg dejen fredag aften — spis friskbagt brød lørdag formiddag.",
-      JSON.stringify([
-        "Fredag aften: Bland 450g hvedemel, 50g rugmel, 375g lunkent vand og 100g aktiv surdej i en skål. Lad det hvile 30 minutter (autolyse).",
-        "Tilsæt 10g salt opløst i 25g vand. Fold dejen 4 gange ved at strække den op og folde den over sig selv. Gentag foldningerne 3-4 gange med 30 minutters interval over 2 timer.",
-        "Form dejen forsigtigt til en rund kugle uden at slå luften ud. Læg i en meldrysset hævekurv (eller en skål beklædt med et meldrysset viskestykke). Dæk til og sæt i køleskab natten over.",
-        "Lørdag morgen: Varm ovnen til 250°C med en støbejernsgryde indeni i mindst 45 minutter.",
-        "Vend dejen direkte fra køleskabet ned i den glødende gryde. Rids overfladen med en skarp kniv eller rageblad. Bag med låg i 20 minutter, fjern låget og bag videre 20-25 minutter til skorpen er dyb mahognibrun.",
-        "Det sværeste: Lad brødet køle helt af på en rist i mindst 1 time inden du skærer i det. Smulen sætter sig stadig inde i brødet."
-      ]),
-      "https://i.pinimg.com/1200x/53/2c/ea/532cea66f74f8b7f546cd471ee8f5573.jpg", "denmark"
-    );
-    await insertRecipeIngredient.run(r3.lastID, 16, "450", "g");
-    await insertRecipeIngredient.run(r3.lastID, 17, "50", "g");
-    await insertRecipeIngredient.run(r3.lastID, 20, "375", "g");
-    await insertRecipeIngredient.run(r3.lastID, 19, "10", "g");
-    await insertRecipeIngredient.run(r3.lastID, 21, "100", "g");
-    await insertRecipeTag.run(r3.lastID, 6);
-    await insertRecipeTag.run(r3.lastID, 7);
+  // ── Opskrift 3: Surdejsbrød ──
+  const r3 = await insertRecipe.run(
+    "Rustikt surdejsbrød", 60, "12.00",
+    "https://www.theperfectloaf.com/beginners-sourdough-bread/",
+    "Et brød der tager to dage, men kræver kun 20 minutters aktiv tid. Den lange koldhævning udvikler en kompleks, let syrlig smag og en sprød, karamelliseret skorpe. Læg dejen fredag aften — spis friskbagt brød lørdag formiddag.",
+    JSON.stringify([
+      "Fredag aften: Bland 450g hvedemel, 50g rugmel, 375g lunkent vand og 100g aktiv surdej i en skål. Lad det hvile 30 minutter (autolyse).",
+      "Tilsæt 10g salt opløst i 25g vand. Fold dejen 4 gange ved at strække den op og folde den over sig selv. Gentag foldningerne 3-4 gange med 30 minutters interval over 2 timer.",
+      "Form dejen forsigtigt til en rund kugle uden at slå luften ud. Læg i en meldrysset hævekurv (eller en skål beklædt med et meldrysset viskestykke). Dæk til og sæt i køleskab natten over.",
+      "Lørdag morgen: Varm ovnen til 250°C med en støbejernsgryde indeni i mindst 45 minutter.",
+      "Vend dejen direkte fra køleskabet ned i den glødende gryde. Rids overfladen med en skarp kniv eller rageblad. Bag med låg i 20 minutter, fjern låget og bag videre 20-25 minutter til skorpen er dyb mahognibrun.",
+      "Det sværeste: Lad brødet køle helt af på en rist i mindst 1 time inden du skærer i det. Smulen sætter sig stadig inde i brødet."
+    ]),
+    "https://i.pinimg.com/1200x/53/2c/ea/532cea66f74f8b7f546cd471ee8f5573.jpg", "denmark"
+  );
+  await insertRecipeIngredient.run(r3.lastID, 16, "450", "g");
+  await insertRecipeIngredient.run(r3.lastID, 17, "50", "g");
+  await insertRecipeIngredient.run(r3.lastID, 20, "375", "g");
+  await insertRecipeIngredient.run(r3.lastID, 19, "10", "g");
+  await insertRecipeIngredient.run(r3.lastID, 21, "100", "g");
+  await insertRecipeTag.run(r3.lastID, 6);
+  await insertRecipeTag.run(r3.lastID, 7);
 
-    // ── Opskrift 4: Torsk med beurre blanc ──
-    const r4 = await insertRecipe.run(
-      "Pandestegte torskeloins med beurre blanc", 25, "95.00",
-      "https://www.greatbritishchefs.com/recipes/pan-fried-cod-beurre-blanc-recipe",
-      "En smukt simpel ret der handler om råvarerne. Perfekt stegte torskeloins — sprød og gylden på den ene side, perlemorshvid og saftig igennem — med en klassisk fransk smørsauce der binder det hele.",
-      JSON.stringify([
-        "Tag torsken ud af køleskabet 20 minutter inden tilberedning — tempereret fisk steger mere jævnt. Dup dem tørre med køkkenrulle og krydr med salt.",
-        "Beurre blanc: Kog hvidvin, finthakket skalotteløg og en skvæt citronsaft ind til næsten ingenting i en lille kasserolle. Tilsæt fløden og kog ind til det halve. Skru ned til meget lav varme.",
-        "Pisk koldt smør i den varme reduktion — et par tern ad gangen — til saucen er blank, tyk og emulgeret. Smag til med salt og citronsaft. Hold varm over vandbad.",
-        "Varm olivenolie i en pande til den er meget varm. Læg torsken i med skindsiden nedad (eller den pæneste side). Pres let ned de første 10 sekunder. Steg uden at røre i 4-5 minutter til den er gylden og knasende.",
-        "Vend forsigtigt og steg 1-2 minutter på den anden side. Fisken er færdig når den akkurat er uigennemsigtig igennem.",
-        "Anret torsken med den gyldne side opad. Hæld beurre blanc henover ved bordet."
-      ]),
-      "https://i.pinimg.com/1200x/11/ca/71/11ca71a2b2ae94f5d19697695b75409e.jpg", "france"
-    );
-    await insertRecipeIngredient.run(r4.lastID, 23, "600", "g");
-    await insertRecipeIngredient.run(r4.lastID, 24, "150", "ml");
-    await insertRecipeIngredient.run(r4.lastID, 25, "2", "stk");
-    await insertRecipeIngredient.run(r4.lastID, 26, "150", "g");
-    await insertRecipeIngredient.run(r4.lastID, 27, "2", "spsk");
-    await insertRecipeIngredient.run(r4.lastID, 28, "1", "stk");
-    await insertRecipeTag.run(r4.lastID, 5);
-    await insertRecipeTag.run(r4.lastID, 3);
+  // ── Opskrift 4: Torsk med beurre blanc ──
+  const r4 = await insertRecipe.run(
+    "Pandestegte torskeloins med beurre blanc", 25, "95.00",
+    "https://www.greatbritishchefs.com/recipes/pan-fried-cod-beurre-blanc-recipe",
+    "En smukt simpel ret der handler om råvarerne. Perfekt stegte torskeloins — sprød og gylden på den ene side, perlemorshvid og saftig igennem — med en klassisk fransk smørsauce der binder det hele.",
+    JSON.stringify([
+      "Tag torsken ud af køleskabet 20 minutter inden tilberedning — tempereret fisk steger mere jævnt. Dup dem tørre med køkkenrulle og krydr med salt.",
+      "Beurre blanc: Kog hvidvin, finthakket skalotteløg og en skvæt citronsaft ind til næsten ingenting i en lille kasserolle. Tilsæt fløden og kog ind til det halve. Skru ned til meget lav varme.",
+      "Pisk koldt smør i den varme reduktion — et par tern ad gangen — til saucen er blank, tyk og emulgeret. Smag til med salt og citronsaft. Hold varm over vandbad.",
+      "Varm olivenolie i en pande til den er meget varm. Læg torsken i med skindsiden nedad (eller den pæneste side). Pres let ned de første 10 sekunder. Steg uden at røre i 4-5 minutter til den er gylden og knasende.",
+      "Vend forsigtigt og steg 1-2 minutter på den anden side. Fisken er færdig når den akkurat er uigennemsigtig igennem.",
+      "Anret torsken med den gyldne side opad. Hæld beurre blanc henover ved bordet."
+    ]),
+    "https://i.pinimg.com/1200x/11/ca/71/11ca71a2b2ae94f5d19697695b75409e.jpg", "france"
+  );
+  await insertRecipeIngredient.run(r4.lastID, 23, "600", "g");
+  await insertRecipeIngredient.run(r4.lastID, 24, "150", "ml");
+  await insertRecipeIngredient.run(r4.lastID, 25, "2", "stk");
+  await insertRecipeIngredient.run(r4.lastID, 26, "150", "g");
+  await insertRecipeIngredient.run(r4.lastID, 27, "2", "spsk");
+  await insertRecipeIngredient.run(r4.lastID, 28, "1", "stk");
+  await insertRecipeTag.run(r4.lastID, 5);
+  await insertRecipeTag.run(r4.lastID, 3);
 
-    // ── New ingredients for remaining countries (29-60) ──
-    await insertIngredient.run("Kyllingebryst");           // 29
-    await insertIngredient.run("Panko rasp");              // 30
-    await insertIngredient.run("Japansk karry");           // 31
-    await insertIngredient.run("Kartoffel");               // 32
-    await insertIngredient.run("Ris");                     // 33
-    await insertIngredient.run("Svinekød (nakkefilet)");   // 34
-    await insertIngredient.run("Ananas");                  // 35
-    await insertIngredient.run("Chipotle i adobo");        // 36
-    await insertIngredient.run("Koriander (frisk)");       // 37
-    await insertIngredient.run("Lime");                    // 38
-    await insertIngredient.run("Hvede-tortillas");         // 39
-    await insertIngredient.run("Achiote-pasta");           // 40
-    await insertIngredient.run("Kyllingelår (udbenet)");   // 41
-    await insertIngredient.run("Yoghurt (naturel)");       // 42
-    await insertIngredient.run("Garam masala");            // 43
-    await insertIngredient.run("Flåede tomater");          // 44
-    await insertIngredient.run("Ingefær (frisk)");         // 45
-    await insertIngredient.run("Chili (frisk grøn)");      // 46
-    await insertIngredient.run("Lammebov");                // 47
-    await insertIngredient.run("Dadler (tørrede)");        // 48
-    await insertIngredient.run("Mandler (hele)");          // 49
-    await insertIngredient.run("Safran");                  // 50
-    await insertIngredient.run("Kanel (stang)");           // 51
-    await insertIngredient.run("Spidskommen");             // 52
-    await insertIngredient.run("Kikærter (dåse)");         // 53
-    await insertIngredient.run("Risnudler (brede)");       // 54
-    await insertIngredient.run("Rejer (pillede)");         // 55
-    await insertIngredient.run("Tamarindpasta");           // 56
-    await insertIngredient.run("Fiskesauce");              // 57
-    await insertIngredient.run("Peanuts (ristede)");       // 58
-    await insertIngredient.run("Bønnespirer");             // 59
-    await insertIngredient.run("Forårsløg");               // 60
+  // ── New ingredients for remaining countries (29-60) ──
+  await insertIngredient.run("Kyllingebryst");           // 29
+  await insertIngredient.run("Panko rasp");              // 30
+  await insertIngredient.run("Japansk karry");           // 31
+  await insertIngredient.run("Kartoffel");               // 32
+  await insertIngredient.run("Ris");                     // 33
+  await insertIngredient.run("Svinekød (nakkefilet)");   // 34
+  await insertIngredient.run("Ananas");                  // 35
+  await insertIngredient.run("Chipotle i adobo");        // 36
+  await insertIngredient.run("Koriander (frisk)");       // 37
+  await insertIngredient.run("Lime");                    // 38
+  await insertIngredient.run("Hvede-tortillas");         // 39
+  await insertIngredient.run("Achiote-pasta");           // 40
+  await insertIngredient.run("Kyllingelår (udbenet)");   // 41
+  await insertIngredient.run("Yoghurt (naturel)");       // 42
+  await insertIngredient.run("Garam masala");            // 43
+  await insertIngredient.run("Flåede tomater");          // 44
+  await insertIngredient.run("Ingefær (frisk)");         // 45
+  await insertIngredient.run("Chili (frisk grøn)");      // 46
+  await insertIngredient.run("Lammebov");                // 47
+  await insertIngredient.run("Dadler (tørrede)");        // 48
+  await insertIngredient.run("Mandler (hele)");          // 49
+  await insertIngredient.run("Safran");                  // 50
+  await insertIngredient.run("Kanel (stang)");           // 51
+  await insertIngredient.run("Spidskommen");             // 52
+  await insertIngredient.run("Kikærter (dåse)");         // 53
+  await insertIngredient.run("Risnudler (brede)");       // 54
+  await insertIngredient.run("Rejer (pillede)");         // 55
+  await insertIngredient.run("Tamarindpasta");           // 56
+  await insertIngredient.run("Fiskesauce");              // 57
+  await insertIngredient.run("Peanuts (ristede)");       // 58
+  await insertIngredient.run("Bønnespirer");             // 59
+  await insertIngredient.run("Forårsløg");               // 60
 
-    // ── New tags (8-13) ──
-    await insertTag.run("Japansk");      // 8
-    await insertTag.run("Mexicansk");    // 9
-    await insertTag.run("Streetfood");   // 10
-    await insertTag.run("Indisk");       // 11
-    await insertTag.run("Marokkansk");   // 12
-    await insertTag.run("Thailandsk");   // 13
+  // ── New tags (8-13) ──
+  await insertTag.run("Japansk");      // 8
+  await insertTag.run("Mexicansk");    // 9
+  await insertTag.run("Streetfood");   // 10
+  await insertTag.run("Indisk");       // 11
+  await insertTag.run("Marokkansk");   // 12
+  await insertTag.run("Thailandsk");   // 13
 
-    // ── Opskrift 5: Chicken Katsu Curry (Japan) ──
-    const r5 = await insertRecipe.run(
-      "Chicken Katsu Curry", 50, "55.00",
-      "https://www.justonecookbook.com/katsu-curry/",
-      "Japansk comfort food i verdensklasse. Sprød, panko-paneret kylling serveret over dampende ris med en blød, sødlig karry-sauce der er helt sin egen — tykkere og mere frugtig end indisk karry. Ugens bedste tirsdag.",
-      JSON.stringify([
-        "Kog karry-saucen: Svits løg og gulerod i smør til bløde. Tilsæt japansk karrypasta og 500 ml vand. Kog 15 minutter til saucen er tyk og glat.",
-        "Bank kyllingebrysterne flade med en kødhammer. Krydr med salt og peber.",
-        "Paner kyllingen: mel → pisket æg → panko rasp. Tryk panko-en godt fast.",
-        "Steg kyllingen i rigeligt olie ved 170°C i 5-6 minutter per side til den er dybt gylden og gennemstegt.",
-        "Lad kyllingen hvile 2 minutter på et rist, skær derefter i tykke skiver på skrå.",
-        "Anret over dampende ris. Hæld karry-saucen ved siden af, så panko'en forbliver sprød."
-      ]),
-      "https://i.pinimg.com/1200x/bb/7c/97/bb7c9754d6a10f5742fd52f8e59b6a65.jpg", "japan"
-    );
-    await insertRecipeIngredient.run(r5.lastID, 29, "2", "stk");
-    await insertRecipeIngredient.run(r5.lastID, 30, "100", "g");
-    await insertRecipeIngredient.run(r5.lastID, 31, "80", "g");
-    await insertRecipeIngredient.run(r5.lastID, 13, "1", "stk");
-    await insertRecipeIngredient.run(r5.lastID, 14, "1", "stk");
-    await insertRecipeIngredient.run(r5.lastID, 33, "300", "g");
-    await insertRecipeIngredient.run(r5.lastID, 3, "2", "stk");
-    await insertRecipeIngredient.run(r5.lastID, 16, "50", "g");
-    await insertRecipeTag.run(r5.lastID, 8);
-    await insertRecipeTag.run(r5.lastID, 3);
+  // ── Opskrift 5: Chicken Katsu Curry (Japan) ──
+  const r5 = await insertRecipe.run(
+    "Chicken Katsu Curry", 50, "55.00",
+    "https://www.justonecookbook.com/katsu-curry/",
+    "Japansk comfort food i verdensklasse. Sprød, panko-paneret kylling serveret over dampende ris med en blød, sødlig karry-sauce der er helt sin egen — tykkere og mere frugtig end indisk karry. Ugens bedste tirsdag.",
+    JSON.stringify([
+      "Kog karry-saucen: Svits løg og gulerod i smør til bløde. Tilsæt japansk karrypasta og 500 ml vand. Kog 15 minutter til saucen er tyk og glat.",
+      "Bank kyllingebrysterne flade med en kødhammer. Krydr med salt og peber.",
+      "Paner kyllingen: mel → pisket æg → panko rasp. Tryk panko-en godt fast.",
+      "Steg kyllingen i rigeligt olie ved 170°C i 5-6 minutter per side til den er dybt gylden og gennemstegt.",
+      "Lad kyllingen hvile 2 minutter på et rist, skær derefter i tykke skiver på skrå.",
+      "Anret over dampende ris. Hæld karry-saucen ved siden af, så panko'en forbliver sprød."
+    ]),
+    "https://i.pinimg.com/1200x/bb/7c/97/bb7c9754d6a10f5742fd52f8e59b6a65.jpg", "japan"
+  );
+  await insertRecipeIngredient.run(r5.lastID, 29, "2", "stk");
+  await insertRecipeIngredient.run(r5.lastID, 30, "100", "g");
+  await insertRecipeIngredient.run(r5.lastID, 31, "80", "g");
+  await insertRecipeIngredient.run(r5.lastID, 13, "1", "stk");
+  await insertRecipeIngredient.run(r5.lastID, 14, "1", "stk");
+  await insertRecipeIngredient.run(r5.lastID, 33, "300", "g");
+  await insertRecipeIngredient.run(r5.lastID, 3, "2", "stk");
+  await insertRecipeIngredient.run(r5.lastID, 16, "50", "g");
+  await insertRecipeTag.run(r5.lastID, 8);
+  await insertRecipeTag.run(r5.lastID, 3);
 
-    // ── Opskrift 6: Tacos al Pastor (Mexico) ──
-    const r6 = await insertRecipe.run(
-      "Tacos al Pastor", 75, "65.00",
-      "https://www.seriouseats.com/tacos-al-pastor-recipe",
-      "Mexico Citys mest ikoniske streetfood. Tyndt skåret svinekød marineret i en rød, let sød achiote-chili marinade, grillet til karamelliseret og serveret med frisk ananas, koriander og lime i varme tortillas.",
-      JSON.stringify([
-        "Bland achiote-pasta, chipotle i adobo, hvidløg, appelsinsaft, eddike og krydderier til en glat marinade i en blender.",
-        "Skær svinekødet i tynde skiver (3-4 mm) og vend det grundigt i marinaden. Dæk til og lad det trække mindst 2 timer — gerne natten over.",
-        "Varm en grillpande eller grill til høj varme. Gril kødet i 2-3 minutter per side til karamelliseret og let forkullede kanter.",
-        "Gril ananas-skiver ved siden af til de har grillmærker — ca. 2 minutter per side. Skær i små tern.",
-        "Varm tortillas direkte over en gasflamme eller i en tør pande til de er bløde og let svitsede.",
-        "Saml tacos: kød, ananas, finthakket løg, koriander og et generøst skvæt lime. Server straks."
-      ]),
-      "https://i.pinimg.com/1200x/8f/41/fd/8f41fd55427d5ddff6f637299064f142.jpg", "mexico"
-    );
-    await insertRecipeIngredient.run(r6.lastID, 34, "600", "g");
-    await insertRecipeIngredient.run(r6.lastID, 35, "4", "skiver");
-    await insertRecipeIngredient.run(r6.lastID, 36, "2", "stk");
-    await insertRecipeIngredient.run(r6.lastID, 40, "50", "g");
-    await insertRecipeIngredient.run(r6.lastID, 37, "1", "bundt");
-    await insertRecipeIngredient.run(r6.lastID, 38, "3", "stk");
-    await insertRecipeIngredient.run(r6.lastID, 13, "1", "stk");
-    await insertRecipeIngredient.run(r6.lastID, 39, "12", "stk");
-    await insertRecipeTag.run(r6.lastID, 9);
-    await insertRecipeTag.run(r6.lastID, 10);
+  // ── Opskrift 6: Tacos al Pastor (Mexico) ──
+  const r6 = await insertRecipe.run(
+    "Tacos al Pastor", 75, "65.00",
+    "https://www.seriouseats.com/tacos-al-pastor-recipe",
+    "Mexico Citys mest ikoniske streetfood. Tyndt skåret svinekød marineret i en rød, let sød achiote-chili marinade, grillet til karamelliseret og serveret med frisk ananas, koriander og lime i varme tortillas.",
+    JSON.stringify([
+      "Bland achiote-pasta, chipotle i adobo, hvidløg, appelsinsaft, eddike og krydderier til en glat marinade i en blender.",
+      "Skær svinekødet i tynde skiver (3-4 mm) og vend det grundigt i marinaden. Dæk til og lad det trække mindst 2 timer — gerne natten over.",
+      "Varm en grillpande eller grill til høj varme. Gril kødet i 2-3 minutter per side til karamelliseret og let forkullede kanter.",
+      "Gril ananas-skiver ved siden af til de har grillmærker — ca. 2 minutter per side. Skær i små tern.",
+      "Varm tortillas direkte over en gasflamme eller i en tør pande til de er bløde og let svitsede.",
+      "Saml tacos: kød, ananas, finthakket løg, koriander og et generøst skvæt lime. Server straks."
+    ]),
+    "https://i.pinimg.com/1200x/8f/41/fd/8f41fd55427d5ddff6f637299064f142.jpg", "mexico"
+  );
+  await insertRecipeIngredient.run(r6.lastID, 34, "600", "g");
+  await insertRecipeIngredient.run(r6.lastID, 35, "4", "skiver");
+  await insertRecipeIngredient.run(r6.lastID, 36, "2", "stk");
+  await insertRecipeIngredient.run(r6.lastID, 40, "50", "g");
+  await insertRecipeIngredient.run(r6.lastID, 37, "1", "bundt");
+  await insertRecipeIngredient.run(r6.lastID, 38, "3", "stk");
+  await insertRecipeIngredient.run(r6.lastID, 13, "1", "stk");
+  await insertRecipeIngredient.run(r6.lastID, 39, "12", "stk");
+  await insertRecipeTag.run(r6.lastID, 9);
+  await insertRecipeTag.run(r6.lastID, 10);
 
-    // ── Opskrift 7: Butter Chicken (Indien) ──
-    const r7 = await insertRecipe.run(
-      "Butter Chicken (Murgh Makhani)", 60, "72.00",
-      "https://www.indianhealthyrecipes.com/butter-chicken/",
-      "Den cremede, tomatsødme klassiker fra Delhi. Kylling marineret i krydret yoghurt, grillet til røget og svøbt i en silkeblød sauce af tomater, smør og fløde. Bedre end takeaway — og du ved hvad der er i.",
-      JSON.stringify([
-        "Marinér kyllingelårene: Bland yoghurt, garam masala, chili, ingefær og hvidløg. Vend kyllingen i marinaden og lad den trække mindst 1 time, helst 4.",
-        "Gril eller steg kyllingen ved høj varme i 5-6 minutter per side til let forkullede kanter. Sæt til side.",
-        "Sauce: Svits løg, ingefær og hvidløg i smør til gyldne. Tilsæt flåede tomater, garam masala og lad det koge 20 minutter.",
-        "Blend saucen glat. Sigt den tilbage i gryden for en helt silkeblød konsistens.",
-        "Tilsæt fløde og smør. Læg kyllingen i saucen og lad det simre 10 minutter til saucen er tyk og klæber til kødet.",
-        "Smag til med salt og et drys tørret fenugreek (kasuri methi) hvis du har det. Server med naan eller basmatiris."
-      ]),
-      "https://i.pinimg.com/1200x/a0/48/4c/a0484cc5bc54fd2d7298f8bb56b257ae.jpg", "india"
-    );
-    await insertRecipeIngredient.run(r7.lastID, 41, "800", "g");
-    await insertRecipeIngredient.run(r7.lastID, 42, "150", "g");
-    await insertRecipeIngredient.run(r7.lastID, 43, "2", "spsk");
-    await insertRecipeIngredient.run(r7.lastID, 44, "400", "g");
-    await insertRecipeIngredient.run(r7.lastID, 26, "60", "g");
-    await insertRecipeIngredient.run(r7.lastID, 27, "100", "ml");
-    await insertRecipeIngredient.run(r7.lastID, 10, "4", "fed");
-    await insertRecipeIngredient.run(r7.lastID, 45, "3", "cm");
-    await insertRecipeIngredient.run(r7.lastID, 46, "2", "stk");
-    await insertRecipeTag.run(r7.lastID, 11);
-    await insertRecipeTag.run(r7.lastID, 3);
+  // ── Opskrift 7: Butter Chicken (Indien) ──
+  const r7 = await insertRecipe.run(
+    "Butter Chicken (Murgh Makhani)", 60, "72.00",
+    "https://www.indianhealthyrecipes.com/butter-chicken/",
+    "Den cremede, tomatsødme klassiker fra Delhi. Kylling marineret i krydret yoghurt, grillet til røget og svøbt i en silkeblød sauce af tomater, smør og fløde. Bedre end takeaway — og du ved hvad der er i.",
+    JSON.stringify([
+      "Marinér kyllingelårene: Bland yoghurt, garam masala, chili, ingefær og hvidløg. Vend kyllingen i marinaden og lad den trække mindst 1 time, helst 4.",
+      "Gril eller steg kyllingen ved høj varme i 5-6 minutter per side til let forkullede kanter. Sæt til side.",
+      "Sauce: Svits løg, ingefær og hvidløg i smør til gyldne. Tilsæt flåede tomater, garam masala og lad det koge 20 minutter.",
+      "Blend saucen glat. Sigt den tilbage i gryden for en helt silkeblød konsistens.",
+      "Tilsæt fløde og smør. Læg kyllingen i saucen og lad det simre 10 minutter til saucen er tyk og klæber til kødet.",
+      "Smag til med salt og et drys tørret fenugreek (kasuri methi) hvis du har det. Server med naan eller basmatiris."
+    ]),
+    "https://i.pinimg.com/1200x/a0/48/4c/a0484cc5bc54fd2d7298f8bb56b257ae.jpg", "india"
+  );
+  await insertRecipeIngredient.run(r7.lastID, 41, "800", "g");
+  await insertRecipeIngredient.run(r7.lastID, 42, "150", "g");
+  await insertRecipeIngredient.run(r7.lastID, 43, "2", "spsk");
+  await insertRecipeIngredient.run(r7.lastID, 44, "400", "g");
+  await insertRecipeIngredient.run(r7.lastID, 26, "60", "g");
+  await insertRecipeIngredient.run(r7.lastID, 27, "100", "ml");
+  await insertRecipeIngredient.run(r7.lastID, 10, "4", "fed");
+  await insertRecipeIngredient.run(r7.lastID, 45, "3", "cm");
+  await insertRecipeIngredient.run(r7.lastID, 46, "2", "stk");
+  await insertRecipeTag.run(r7.lastID, 11);
+  await insertRecipeTag.run(r7.lastID, 3);
 
-    // ── Opskrift 8: Lam-tagine med dadler og mandler (Marokko) ──
-    const r8 = await insertRecipe.run(
-      "Lam-tagine med dadler og mandler", 150, "88.00",
-      "https://www.bbcgoodfood.com/recipes/lamb-tagine",
-      "Marokkansk langsom madlavning på sit bedste. Mørt lammekød, søde dadler, knas af ristede mandler og en aromatisk sauce gennemsyret af safran, kanel og spidskommen. Huset dufter fantastisk i timevis.",
-      JSON.stringify([
-        "Skær lammebov i store tern (4-5 cm). Krydr med salt, spidskommen og kanel. Brun kødet i olivenolie i en tung gryde — arbejd i hold så du får stege-skorpe, ikke damp.",
-        "Svits løg og hvidløg i samme gryde til bløde. Tilsæt safran opløst i 2 spsk varmt vand, resten af krydderierne og tomatpuré. Rør 2 minutter.",
-        "Læg kødet tilbage, tilsæt 400 ml vand og bring i kog. Skru ned til lavt blus, dæk med låg og lad det simre i 1½ time.",
-        "Tilsæt dadler og drænet kikærter. Simre yderligere 30 minutter til kødet falder fra hinanden og saucen er tyk.",
-        "Rist mandler på en tør pande til gyldne — de brænder hurtigt, så hold øje.",
-        "Server taginen drysset med ristede mandler og frisk koriander. Couscous eller brød ved siden af."
-      ]),
-      "https://i.pinimg.com/1200x/b1/a5/68/b1a5685cc332e1c047b67adce392790b.jpg", "morocco"
-    );
-    await insertRecipeIngredient.run(r8.lastID, 47, "800", "g");
-    await insertRecipeIngredient.run(r8.lastID, 48, "100", "g");
-    await insertRecipeIngredient.run(r8.lastID, 49, "60", "g");
-    await insertRecipeIngredient.run(r8.lastID, 50, "1", "knivspids");
-    await insertRecipeIngredient.run(r8.lastID, 51, "1", "stk");
-    await insertRecipeIngredient.run(r8.lastID, 52, "2", "tsk");
-    await insertRecipeIngredient.run(r8.lastID, 13, "2", "stk");
-    await insertRecipeIngredient.run(r8.lastID, 53, "1", "dåse");
-    await insertRecipeIngredient.run(r8.lastID, 37, "1", "bundt");
-    await insertRecipeTag.run(r8.lastID, 12);
-    await insertRecipeTag.run(r8.lastID, 4);
+  // ── Opskrift 8: Lam-tagine med dadler og mandler (Marokko) ──
+  const r8 = await insertRecipe.run(
+    "Lam-tagine med dadler og mandler", 150, "88.00",
+    "https://www.bbcgoodfood.com/recipes/lamb-tagine",
+    "Marokkansk langsom madlavning på sit bedste. Mørt lammekød, søde dadler, knas af ristede mandler og en aromatisk sauce gennemsyret af safran, kanel og spidskommen. Huset dufter fantastisk i timevis.",
+    JSON.stringify([
+      "Skær lammebov i store tern (4-5 cm). Krydr med salt, spidskommen og kanel. Brun kødet i olivenolie i en tung gryde — arbejd i hold så du får stege-skorpe, ikke damp.",
+      "Svits løg og hvidløg i samme gryde til bløde. Tilsæt safran opløst i 2 spsk varmt vand, resten af krydderierne og tomatpuré. Rør 2 minutter.",
+      "Læg kødet tilbage, tilsæt 400 ml vand og bring i kog. Skru ned til lavt blus, dæk med låg og lad det simre i 1½ time.",
+      "Tilsæt dadler og drænet kikærter. Simre yderligere 30 minutter til kødet falder fra hinanden og saucen er tyk.",
+      "Rist mandler på en tør pande til gyldne — de brænder hurtigt, så hold øje.",
+      "Server taginen drysset med ristede mandler og frisk koriander. Couscous eller brød ved siden af."
+    ]),
+    "https://i.pinimg.com/1200x/b1/a5/68/b1a5685cc332e1c047b67adce392790b.jpg", "morocco"
+  );
+  await insertRecipeIngredient.run(r8.lastID, 47, "800", "g");
+  await insertRecipeIngredient.run(r8.lastID, 48, "100", "g");
+  await insertRecipeIngredient.run(r8.lastID, 49, "60", "g");
+  await insertRecipeIngredient.run(r8.lastID, 50, "1", "knivspids");
+  await insertRecipeIngredient.run(r8.lastID, 51, "1", "stk");
+  await insertRecipeIngredient.run(r8.lastID, 52, "2", "tsk");
+  await insertRecipeIngredient.run(r8.lastID, 13, "2", "stk");
+  await insertRecipeIngredient.run(r8.lastID, 53, "1", "dåse");
+  await insertRecipeIngredient.run(r8.lastID, 37, "1", "bundt");
+  await insertRecipeTag.run(r8.lastID, 12);
+  await insertRecipeTag.run(r8.lastID, 4);
 
-    // ── Opskrift 9: Pad Thai (Thailand) ──
-    const r9 = await insertRecipe.run(
-      "Pad Thai", 30, "58.00",
-      "https://hot-thai-kitchen.com/pad-thai/",
-      "Bangkoks berømte gadenudler. Bløde risnudler vendt i en balanceret sauce af tamarind, fiskesauce og palmesukker med sprøde peanuts, friske bønnespirer og et skvæt lime. Hemmeligheden er wok hei — høj varme, hurtige hænder.",
-      JSON.stringify([
-        "Udbløds risnudler i varmt vand i 15-20 minutter til bøjelige men stadig faste — de skal ikke være bløde endnu. Dræn.",
-        "Bland saucen: 3 spsk tamarindpasta, 2 spsk fiskesauce, 2 spsk sukker og 1 spsk vand. Rør til sukkeret er opløst.",
-        "Varm en wok til rygende. Steg rejerne i 1 minut og sæt til side. Tilsæt olie, piskede æg og rør til store klumper. Sæt også til side.",
-        "I samme wok: tilsæt lidt olie, nudlerne og hele saucen. Vend med tang i 2-3 minutter til nudlerne har absorberet saucen og er bløde.",
-        "Tilsæt rejer, æg, halvdelen af bønnespirerne og forårsløg. Vend hurtigt sammen.",
-        "Anret med ristede peanuts, resten af bønnespirerne, limebåde og frisk koriander."
-      ]),
-      "https://i.pinimg.com/1200x/86/36/0d/86360d6aa83b4570417451bcb4d03350.jpg", "thailand"
-    );
-    await insertRecipeIngredient.run(r9.lastID, 54, "250", "g");
-    await insertRecipeIngredient.run(r9.lastID, 55, "200", "g");
-    await insertRecipeIngredient.run(r9.lastID, 56, "3", "spsk");
-    await insertRecipeIngredient.run(r9.lastID, 57, "2", "spsk");
-    await insertRecipeIngredient.run(r9.lastID, 58, "50", "g");
-    await insertRecipeIngredient.run(r9.lastID, 59, "100", "g");
-    await insertRecipeIngredient.run(r9.lastID, 3, "2", "stk");
-    await insertRecipeIngredient.run(r9.lastID, 38, "2", "stk");
-    await insertRecipeIngredient.run(r9.lastID, 60, "3", "stk");
-    await insertRecipeTag.run(r9.lastID, 13);
-    await insertRecipeTag.run(r9.lastID, 10);
+  // ── Opskrift 9: Pad Thai (Thailand) ──
+  const r9 = await insertRecipe.run(
+    "Pad Thai", 30, "58.00",
+    "https://hot-thai-kitchen.com/pad-thai/",
+    "Bangkoks berømte gadenudler. Bløde risnudler vendt i en balanceret sauce af tamarind, fiskesauce og palmesukker med sprøde peanuts, friske bønnespirer og et skvæt lime. Hemmeligheden er wok hei — høj varme, hurtige hænder.",
+    JSON.stringify([
+      "Udbløds risnudler i varmt vand i 15-20 minutter til bøjelige men stadig faste — de skal ikke være bløde endnu. Dræn.",
+      "Bland saucen: 3 spsk tamarindpasta, 2 spsk fiskesauce, 2 spsk sukker og 1 spsk vand. Rør til sukkeret er opløst.",
+      "Varm en wok til rygende. Steg rejerne i 1 minut og sæt til side. Tilsæt olie, piskede æg og rør til store klumper. Sæt også til side.",
+      "I samme wok: tilsæt lidt olie, nudlerne og hele saucen. Vend med tang i 2-3 minutter til nudlerne har absorberet saucen og er bløde.",
+      "Tilsæt rejer, æg, halvdelen af bønnespirerne og forårsløg. Vend hurtigt sammen.",
+      "Anret med ristede peanuts, resten af bønnespirerne, limebåde og frisk koriander."
+    ]),
+    "https://i.pinimg.com/1200x/86/36/0d/86360d6aa83b4570417451bcb4d03350.jpg", "thailand"
+  );
+  await insertRecipeIngredient.run(r9.lastID, 54, "250", "g");
+  await insertRecipeIngredient.run(r9.lastID, 55, "200", "g");
+  await insertRecipeIngredient.run(r9.lastID, 56, "3", "spsk");
+  await insertRecipeIngredient.run(r9.lastID, 57, "2", "spsk");
+  await insertRecipeIngredient.run(r9.lastID, 58, "50", "g");
+  await insertRecipeIngredient.run(r9.lastID, 59, "100", "g");
+  await insertRecipeIngredient.run(r9.lastID, 3, "2", "stk");
+  await insertRecipeIngredient.run(r9.lastID, 38, "2", "stk");
+  await insertRecipeIngredient.run(r9.lastID, 60, "3", "stk");
+  await insertRecipeTag.run(r9.lastID, 13);
+  await insertRecipeTag.run(r9.lastID, 10);
 
 }
 

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,29 @@
+import js from "@eslint/js";
+
+export default [
+  {
+    ignores: ["node_modules/", "dist/", "*.test.js"],
+  },
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        Buffer: "readonly",
+        URL: "readonly",
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      "indent": ["error", 2],
+      "linebreak-style": ["error", "unix"],
+      "quotes": ["error", "double"],
+      "semi": ["error", "always"],
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "no-console": "off",
+    },
+  },
+];

--- a/backend/http/responses.js
+++ b/backend/http/responses.js
@@ -1,0 +1,47 @@
+export function setCorsHeaders(res, req) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    req.headers["access-control-request-headers"] || "Content-Type"
+  );
+  res.setHeader("Vary", "Origin, Access-Control-Request-Headers");
+}
+
+export function send(res, status, body = "", headers = {}) {
+  if (!res.headersSent) {
+    for (const [name, value] of Object.entries(headers)) {
+      res.setHeader(name, value);
+    }
+    res.statusCode = status;
+  }
+
+  if (body === undefined || body === null) {
+    res.end();
+    return;
+  }
+
+  res.end(body);
+}
+
+export function sendJson(res, status, payload) {
+  send(res, status, JSON.stringify(payload), {
+    "Content-Type": "application/json; charset=utf-8",
+  });
+}
+
+export function sendHtml(res, status, html) {
+  send(res, status, html, {
+    "Content-Type": "text/html; charset=utf-8",
+  });
+}
+
+export function sendBuffer(res, status, contentType, buffer) {
+  send(res, status, buffer, {
+    "Content-Type": contentType,
+  });
+}
+
+export function sendNoContent(res, status = 204) {
+  send(res, status);
+}

--- a/backend/http/router.js
+++ b/backend/http/router.js
@@ -1,0 +1,165 @@
+import { HttpError } from "../middleware/error.js";
+import { sendNoContent, setCorsHeaders } from "./responses.js";
+
+const JSON_BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
+const JSON_CONTENT_TYPE = /^application\/(?:[\w.+-]*\+)?json\b/i;
+const ONE_MEBIBYTE = 1024 * 1024;
+
+export function defineRoute(method, path, handler) {
+  return {
+    method: method.toUpperCase(),
+    path,
+    handler,
+  };
+}
+
+export function normalizePathname(pathname) {
+  const normalized = pathname.replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileRoutePath(path) {
+  const normalizedPath = normalizePathname(path);
+  if (normalizedPath === "/") {
+    return { regex: /^\/$/, paramNames: [] };
+  }
+
+  const paramNames = [];
+  const segments = normalizedPath.slice(1).split("/");
+  const pattern = segments.map((segment) => {
+    if (segment === "*") {
+      paramNames.push("wildcard");
+      return "(.*)";
+    }
+
+    if (segment.startsWith(":")) {
+      paramNames.push(segment.slice(1));
+      return "([^/]+)";
+    }
+
+    return escapeRegex(segment);
+  }).join("/");
+
+  return {
+    regex: new RegExp(`^/${pattern}$`),
+    paramNames,
+  };
+}
+
+function matchRoute(route, pathname) {
+  const match = route.regex.exec(pathname);
+  if (!match) return null;
+
+  return route.paramNames.reduce((params, name, index) => {
+    params[name] = decodeURIComponent(match[index + 1] || "");
+    return params;
+  }, {});
+}
+
+function requestHasBody(req) {
+  const contentLength = Number(req.headers["content-length"] || 0);
+  return contentLength > 0 || req.headers["transfer-encoding"] !== undefined;
+}
+
+function shouldParseJsonBody(req) {
+  if (!JSON_BODY_METHODS.has((req.method || "GET").toUpperCase())) {
+    return false;
+  }
+
+  if (!requestHasBody(req)) {
+    return false;
+  }
+
+  return JSON_CONTENT_TYPE.test(req.headers["content-type"] || "");
+}
+
+export async function readJsonBody(req, limitBytes = ONE_MEBIBYTE) {
+  if (!shouldParseJsonBody(req)) {
+    return undefined;
+  }
+
+  const chunks = [];
+  let totalBytes = 0;
+
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+
+    if (totalBytes > limitBytes) {
+      throw new HttpError(413, "Request body too large.");
+    }
+
+    chunks.push(buffer);
+  }
+
+  const rawBody = Buffer.concat(chunks).toString("utf8").trim();
+  if (!rawBody) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(rawBody);
+  } catch {
+    throw new HttpError(400, "Invalid JSON body.");
+  }
+}
+
+export function createRouter(routes, { onError, onNotFound }) {
+  const compiledRoutes = routes.map((route) => {
+    const { regex, paramNames } = compileRoutePath(route.path);
+    return {
+      ...route,
+      regex,
+      paramNames,
+    };
+  });
+
+  return async function requestHandler(req, res) {
+    setCorsHeaders(res, req);
+
+    if ((req.method || "GET").toUpperCase() === "OPTIONS") {
+      sendNoContent(res);
+      return;
+    }
+
+    try {
+      const requestUrl = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+      const pathname = normalizePathname(requestUrl.pathname);
+      const method = (req.method || "GET").toUpperCase();
+
+      let matchedRoute = null;
+      let params = null;
+
+      for (const route of compiledRoutes) {
+        if (route.method !== method) continue;
+
+        params = matchRoute(route, pathname);
+        if (params) {
+          matchedRoute = route;
+          break;
+        }
+      }
+
+      if (!matchedRoute) {
+        throw onNotFound();
+      }
+
+      const body = await readJsonBody(req);
+      await matchedRoute.handler({
+        req,
+        res,
+        body,
+        params,
+        pathname,
+        query: requestUrl.searchParams,
+        url: requestUrl,
+      });
+    } catch (error) {
+      onError(error, req, res);
+    }
+  };
+}

--- a/backend/http/swagger.js
+++ b/backend/http/swagger.js
@@ -1,0 +1,78 @@
+import { readdirSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+import swaggerUiDist from "swagger-ui-dist";
+import { HttpError } from "../middleware/error.js";
+import { defineRoute } from "./router.js";
+import { sendBuffer, sendHtml } from "./responses.js";
+
+const swaggerUiPath = swaggerUiDist.absolutePath();
+const swaggerUiAssets = new Set(readdirSync(swaggerUiPath));
+
+const mimeTypes = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+};
+
+function swaggerHtml(spec) {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cookbook API docs</title>
+    <link rel="stylesheet" href="/apidocs/swagger-ui.css" />
+    <link rel="icon" type="image/png" href="/apidocs/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/apidocs/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html { box-sizing: border-box; overflow-y: scroll; }
+      *, *::before, *::after { box-sizing: inherit; }
+      body { margin: 0; background: #fafafa; }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="/apidocs/swagger-ui-bundle.js"></script>
+    <script src="/apidocs/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({
+        spec: ${JSON.stringify(spec)},
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        layout: "BaseLayout"
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+async function serveSwaggerAsset(res, assetName) {
+  const safeName = path.basename(assetName);
+  if (safeName !== assetName || !swaggerUiAssets.has(safeName)) {
+    throw new HttpError(404, "Ikke fundet.");
+  }
+
+  const extension = path.extname(safeName);
+  const contentType = mimeTypes[extension] || "application/octet-stream";
+  const buffer = await readFile(path.join(swaggerUiPath, safeName));
+  sendBuffer(res, 200, contentType, buffer);
+}
+
+export function createSwaggerRoutes(spec) {
+  const html = swaggerHtml(spec);
+
+  return [
+    defineRoute("GET", "/apidocs", async ({ res }) => {
+      sendHtml(res, 200, html);
+    }),
+    defineRoute("GET", "/apidocs/*", async ({ res, params }) => {
+      await serveSwaggerAsset(res, params.wildcard);
+    }),
+  ];
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,47 +1,66 @@
-import express from "express";
-import cors from "cors";
-import swaggerUi from "swagger-ui-express";
+import http from "http";
 import YAML from "yamljs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { initDb } from "./db/schema.js";
 
-import apiRouter from "./routes/api.js";
-import recipesRouter from "./routes/recipes.js";
+import apiRoutes from "./routes/api.js";
+import recipeRoutes from "./routes/recipes.js";
+import { createRouter, defineRoute } from "./http/router.js";
+import { sendJson } from "./http/responses.js";
+import { createSwaggerRoutes } from "./http/swagger.js";
 import { errorHandler, notFound } from "./middleware/error.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-const app = express();
 const PORT = process.env.PORT || 3000;
-
-// Load OpenAPI spec
 const swaggerDocument = YAML.load(path.join(__dirname, "..", "openapi.yaml"));
 
-await initDb();
 
-app.use(cors());
-app.use(express.json({ limit: '1mb' }));
+function createRoutes() {
+  return [
+    defineRoute("GET", "/health", async ({ res }) => {
+      sendJson(res, 200, {
+        status: "ok",
+        timestamp: new Date().toISOString(),
+      });
+    }),
+    ...createSwaggerRoutes(swaggerDocument),
+    ...apiRoutes,
+    ...recipeRoutes,
+  ];
+}
 
-// Swagger UI
-app.use("/apidocs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
-
-// Health check
-app.get("/health", (req, res) => {
-  res.status(200).json({ 
-    status: "ok", 
-    timestamp: new Date().toISOString() 
+export function createApp() {
+  return createRouter(createRoutes(), {
+    onError: errorHandler,
+    onNotFound: notFound,
   });
-});
+}
 
-// samme base paths som Flask
-app.use("/api", apiRouter);
-app.use("/api/recipe", recipesRouter);
+export async function createServer() {
+  await initDb();
+  return http.createServer(createApp());
+}
 
-app.use(notFound);
-app.use(errorHandler);
+export async function startServer(port = PORT, host = "0.0.0.0") {
+  const server = await createServer();
 
-app.listen(PORT, "0.0.0.0", () => {
-  console.log(`Node API running: http://localhost:${PORT}`);
-});
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  console.log(`Node API running: http://localhost:${port}`);
+  return server;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  startServer().catch((error) => {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  });
+}

--- a/backend/index.test.js
+++ b/backend/index.test.js
@@ -1,0 +1,216 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer } from "./index.js";
+
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  server = await createServer();
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+});
+
+async function request(path, init) {
+  const response = await fetch(`${baseUrl}${path}`, init);
+  const text = await response.text();
+
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = null;
+    }
+  }
+
+  return { response, text, json };
+}
+
+describe("backend HTTP server", () => {
+  it("serves health and API metadata endpoints", async () => {
+    const health = await request("/health/");
+    expect(health.response.status).toBe(200);
+    expect(health.json).toMatchObject({
+      status: "ok",
+      timestamp: expect.any(String),
+    });
+
+    const api = await request("/api/");
+    expect(api.response.status).toBe(200);
+    expect(api.json).toEqual({
+      message: "Cookbook API",
+      version: "1.0.0",
+      endpoints: {
+        recipe: "/api/recipe",
+      },
+    });
+  });
+
+  it("serves Swagger UI without Express", async () => {
+    const docs = await request("/apidocs");
+    expect(docs.response.status).toBe(200);
+    expect(docs.response.headers.get("content-type")).toContain("text/html");
+    expect(docs.text).toContain("SwaggerUIBundle");
+
+    const asset = await request("/apidocs/swagger-ui-bundle.js");
+    expect(asset.response.status).toBe(200);
+    expect(asset.response.headers.get("content-type")).toContain("text/javascript");
+  });
+
+  it("lists recipe resources", async () => {
+    const recipes = await request("/api/recipe/recipes/");
+    expect(recipes.response.status).toBe(200);
+    expect(recipes.json.length).toBeGreaterThan(0);
+
+    const countryRecipes = await request("/api/recipe/recipes/country/italy/");
+    expect(countryRecipes.response.status).toBe(200);
+    expect(countryRecipes.json.length).toBeGreaterThan(0);
+
+    const ingredients = await request("/api/recipe/ingredients/");
+    expect(ingredients.response.status).toBe(200);
+    expect(Array.isArray(ingredients.json)).toBe(true);
+
+    const tags = await request("/api/recipe/tags/");
+    expect(tags.response.status).toBe(200);
+    expect(Array.isArray(tags.json)).toBe(true);
+  });
+
+  it("supports recipe CRUD through the node:http routing layer", async () => {
+    const payload = {
+      title: `HTTP Test Recipe ${Date.now()}`,
+      description: "created through http server test",
+      time_minutes: 15,
+      price: "25",
+      link: "https://example.com/test-recipe",
+      instructions: ["mix", "serve"],
+      ingredients: [{ name: "Test Ingredient", amount: "2", unit: "pcs" }],
+      tags: [{ name: "Test Tag" }],
+      country: "denmark",
+    };
+
+    const created = await request("/api/recipe/recipes/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    expect(created.response.status).toBe(201);
+    expect(created.json).toMatchObject(payload);
+    expect(created.json.id).toEqual(expect.any(Number));
+
+    const recipeId = created.json.id;
+
+    const fetched = await request(`/api/recipe/recipes/${recipeId}/`);
+    expect(fetched.response.status).toBe(200);
+    expect(fetched.json).toMatchObject({
+      id: recipeId,
+      title: payload.title,
+      instructions: payload.instructions,
+    });
+
+    const updatedPayload = {
+      ...payload,
+      title: `${payload.title} updated`,
+      ingredients: [{ name: "Updated Ingredient", amount: "1", unit: "bowl" }],
+      tags: [{ name: "Updated Tag" }],
+    };
+
+    const updated = await request(`/api/recipe/recipes/${recipeId}/`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(updatedPayload),
+    });
+    expect(updated.response.status).toBe(200);
+    expect(updated.json).toMatchObject({
+      id: recipeId,
+      title: updatedPayload.title,
+    });
+
+    const deleted = await request(`/api/recipe/recipes/${recipeId}/`, {
+      method: "DELETE",
+    });
+    expect(deleted.response.status).toBe(204);
+    expect(deleted.text).toBe("");
+
+    const missing = await request(`/api/recipe/recipes/${recipeId}/`);
+    expect(missing.response.status).toBe(404);
+    expect(missing.json).toEqual({
+      error: "Opskriften blev ikke fundet.",
+    });
+  });
+
+  it("returns 400 for invalid payloads", async () => {
+    const missingTitle = await request("/api/recipe/recipes/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ description: "missing title" }),
+    });
+    expect(missingTitle.response.status).toBe(400);
+    expect(missingTitle.json).toEqual({
+      error: "Opskriften skal have et navn.",
+    });
+
+    const invalidJson = await request("/api/recipe/recipes/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: "{not-valid-json}",
+    });
+    expect(invalidJson.response.status).toBe(400);
+    expect(invalidJson.json).toEqual({
+      error: "Invalid JSON body.",
+    });
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const missing = await request("/missing");
+    expect(missing.response.status).toBe(404);
+    expect(missing.json).toEqual({
+      error: "Ikke fundet.",
+    });
+  });
+
+  it("responds to CORS preflight requests", async () => {
+    const response = await fetch(`${baseUrl}/api/recipe/recipes/`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:5173",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type",
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(response.headers.get("access-control-allow-headers")).toBe("Content-Type");
+  });
+});

--- a/backend/middleware/asyncHandler.js
+++ b/backend/middleware/asyncHandler.js
@@ -1,4 +1,0 @@
-// Wraps an async route handler so any thrown error reaches the error middleware
-// via next(err) instead of becoming an unhandled promise rejection.
-export const asyncHandler = (fn) => (req, res, next) =>
-  Promise.resolve(fn(req, res, next)).catch(next);

--- a/backend/middleware/error.js
+++ b/backend/middleware/error.js
@@ -5,16 +5,24 @@ export class HttpError extends Error {
   }
 }
 
-export function notFound(req, res, next) {
-  next(new HttpError(404, "Ikke fundet."));
+export function notFound() {
+  return new HttpError(404, "Ikke fundet.");
 }
 
-// Express requires the 4-arg signature to identify this as an error handler.
-export function errorHandler(err, req, res, _next) {
+export function errorHandler(err, req, res) {
   const status = err.status || err.statusCode || 500;
   if (status >= 500) {
-    console.error(`${req.method} ${req.path} →`, err);
+    console.error(`${req.method} ${req.url} →`, err);
   }
+
   const message = status >= 500 ? "Der opstod en serverfejl." : err.message;
-  res.status(status).json({ error: message });
+
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify({ error: message }));
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,11 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "cors": "^2.8.5",
-        "express": "^4.18.2",
         "pg": "8.21.0",
         "sqlite3": "^6.0.1",
-        "swagger-ui-express": "^4.6.3",
+        "swagger-ui-dist": "5.31.0",
         "yamljs": "^0.3.0"
       },
       "devDependencies": {
@@ -590,19 +588,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -635,12 +620,6 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -711,30 +690,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -780,15 +735,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/cacache": {
@@ -870,35 +816,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -949,74 +866,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -1042,25 +897,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1068,35 +904,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
@@ -1118,47 +925,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/estree-walker": {
@@ -1169,15 +940,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/expand-template": {
@@ -1206,52 +968,6 @@
       "license": "Apache-2.0",
       "optional": true
     },
-    "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1269,42 +985,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/fs-constants": {
@@ -1347,52 +1027,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -1433,18 +1067,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1462,56 +1084,12 @@
         "node": ">=4"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause",
       "optional": true
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -1591,18 +1169,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1661,15 +1227,6 @@
       "optional": true,
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-binary-path": {
@@ -2043,75 +1600,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -2299,12 +1787,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2329,15 +1811,6 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/node-abi": {
       "version": "3.87.0",
@@ -2504,27 +1977,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2535,18 +1987,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2568,15 +2008,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -2604,12 +2035,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2831,19 +2256,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -2859,45 +2271,6 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/rc": {
@@ -3000,7 +2373,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3012,129 +2386,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3340,15 +2591,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -3394,21 +2636,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
-      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=4.11.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar": {
@@ -3549,15 +2776,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -3588,19 +2806,6 @@
         "node": "*"
       }
     },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -3608,38 +2813,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/vite": {
       "version": "8.0.10",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,8 @@
         "yamljs": "^0.3.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
+        "eslint": "^9.39.4",
         "nodemon": "^3.1.14",
         "vitest": "^4.1.5"
       }
@@ -53,6 +55,163 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@gar/promise-retry": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
@@ -61,6 +220,72 @@
       "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -465,6 +690,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -588,6 +820,29 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -596,6 +851,39 @@
       "optional": true,
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -816,6 +1104,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -824,6 +1122,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -860,6 +1198,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -872,6 +1230,62 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -896,6 +1310,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -932,6 +1353,176 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -940,6 +1531,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expand-template": {
@@ -968,6 +1569,40 @@
       "license": "Apache-2.0",
       "optional": true
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -986,6 +1621,44 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -1067,6 +1740,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1105,31 +1791,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1143,31 +1804,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1189,12 +1825,49 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1283,6 +1956,71 @@
       "optional": true,
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1546,6 +2284,29 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
@@ -1787,6 +2548,13 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1810,6 +2578,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -1910,24 +2685,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/nodemon/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1943,13 +2700,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "9.0.0",
@@ -1997,6 +2747,56 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
@@ -2010,6 +2810,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2017,6 +2840,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
@@ -2246,6 +3079,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -2271,6 +3114,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rc": {
@@ -2313,6 +3166,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rolldown": {
@@ -2386,6 +3249,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -2493,31 +3379,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2806,12 +3667,35 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -3046,6 +3930,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3082,6 +3976,19 @@
       "bin": {
         "json2yaml": "bin/json2yaml",
         "yaml2json": "bin/yaml2json"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cookbook",
   "version": "1.0.0",
-  "description": "Cookbook web application built with Node.js, Express, SQLite3, and Postgres",
+  "description": "Cookbook web application built with Node.js, SQLite3, and Postgres",
   "type": "module",
   "main": "index.js",
   "scripts": {
@@ -16,11 +16,9 @@
   "author": "BalladeBaderne",
   "license": "MIT",
   "dependencies": {
-    "cors": "^2.8.5",
-    "express": "^4.18.2",
     "pg": "8.21.0",
     "sqlite3": "^6.0.1",
-    "swagger-ui-express": "^4.6.3",
+    "swagger-ui-dist": "5.31.0",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "keywords": [
     "cookbook",
@@ -22,6 +24,8 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
     "nodemon": "^3.1.14",
     "vitest": "^4.1.5"
   }

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -1,16 +1,15 @@
-import { Router } from "express";
+import { defineRoute } from "../http/router.js";
+import { sendJson } from "../http/responses.js";
 
-const router = Router();
-
-router.get("/", (req, res) => {
-  console.log("Route invoked: GET /api");
-  res.status(200).json({
-    message: "Cookbook API",
-    version: "1.0.0",
-    endpoints: {
-      recipe: "/api/recipe"
-    }
-  });
-});
-
-export default router;
+export default [
+  defineRoute("GET", "/api", async ({ res }) => {
+    console.log("Route invoked: GET /api");
+    sendJson(res, 200, {
+      message: "Cookbook API",
+      version: "1.0.0",
+      endpoints: {
+        recipe: "/api/recipe",
+      },
+    });
+  }),
+];

--- a/backend/routes/recipes.js
+++ b/backend/routes/recipes.js
@@ -1,51 +1,53 @@
-import { Router } from "express";
 import * as recipes from "../services/recipes.js";
-import { asyncHandler } from "../middleware/asyncHandler.js";
 import { HttpError } from "../middleware/error.js";
+import { sendJson, sendNoContent } from "../http/responses.js";
+import { defineRoute } from "../http/router.js";
 
-const router = Router();
+export default [
+  defineRoute("GET", "/api/recipe/recipes", async ({ res }) => {
+    sendJson(res, 200, await recipes.listRecipes());
+  }),
 
-router.get("/recipes/", asyncHandler(async (req, res) => {
-  res.json(await recipes.listRecipes());
-}));
+  defineRoute("POST", "/api/recipe/recipes", async ({ res, body }) => {
+    const data = body || {};
+    if (!data.title?.trim()) throw new HttpError(400, "Opskriften skal have et navn.");
 
-router.post("/recipes/", asyncHandler(async (req, res) => {
-  const data = req.body || {};
-  if (!data.title?.trim()) throw new HttpError(400, "Opskriften skal have et navn.");
-  const id = await recipes.createRecipe(data);
-  res.status(201).json({ id, ...data });
-}));
+    const id = await recipes.createRecipe(data);
+    sendJson(res, 201, { id, ...data });
+  }),
 
-router.get("/recipes/country/:country", asyncHandler(async (req, res) => {
-  res.json(await recipes.listRecipesByCountry(req.params.country));
-}));
+  defineRoute("GET", "/api/recipe/recipes/country/:country", async ({ res, params }) => {
+    sendJson(res, 200, await recipes.listRecipesByCountry(params.country));
+  }),
 
-router.get("/recipes/:id/", asyncHandler(async (req, res) => {
-  const recipe = await recipes.getRecipe(Number(req.params.id));
-  if (!recipe) throw new HttpError(404, "Opskriften blev ikke fundet.");
-  res.json(recipe);
-}));
+  defineRoute("GET", "/api/recipe/recipes/:id", async ({ res, params }) => {
+    const recipe = await recipes.getRecipe(Number(params.id));
+    if (!recipe) throw new HttpError(404, "Opskriften blev ikke fundet.");
 
-router.put("/recipes/:id/", asyncHandler(async (req, res) => {
-  const id = Number(req.params.id);
-  const data = req.body || {};
-  if (!data.title?.trim()) throw new HttpError(400, "Opskriften skal have et navn.");
-  const ok = await recipes.updateRecipe(id, data);
-  if (!ok) throw new HttpError(404, "Opskriften blev ikke fundet.");
-  res.json({ id, ...data });
-}));
+    sendJson(res, 200, recipe);
+  }),
 
-router.delete("/recipes/:id/", asyncHandler(async (req, res) => {
-  await recipes.deleteRecipe(Number(req.params.id));
-  res.status(204).send("");
-}));
+  defineRoute("PUT", "/api/recipe/recipes/:id", async ({ res, params, body }) => {
+    const id = Number(params.id);
+    const data = body || {};
+    if (!data.title?.trim()) throw new HttpError(400, "Opskriften skal have et navn.");
 
-router.get("/ingredients/", asyncHandler(async (req, res) => {
-  res.json(await recipes.listIngredients());
-}));
+    const ok = await recipes.updateRecipe(id, data);
+    if (!ok) throw new HttpError(404, "Opskriften blev ikke fundet.");
 
-router.get("/tags/", asyncHandler(async (req, res) => {
-  res.json(await recipes.listTags());
-}));
+    sendJson(res, 200, { id, ...data });
+  }),
 
-export default router;
+  defineRoute("DELETE", "/api/recipe/recipes/:id", async ({ res, params }) => {
+    await recipes.deleteRecipe(Number(params.id));
+    sendNoContent(res);
+  }),
+
+  defineRoute("GET", "/api/recipe/ingredients", async ({ res }) => {
+    sendJson(res, 200, await recipes.listIngredients());
+  }),
+
+  defineRoute("GET", "/api/recipe/tags", async ({ res }) => {
+    sendJson(res, 200, await recipes.listTags());
+  }),
+];

--- a/backend/services/recipes.js
+++ b/backend/services/recipes.js
@@ -1,17 +1,17 @@
 import { db } from "../db/index.js";
 
 async function upsertIngredient(name, conn = db) {
-  let row = await conn.prepare(`SELECT id FROM ingredients WHERE name = ?`).get(name);
+  let row = await conn.prepare("SELECT id FROM ingredients WHERE name = ?").get(name);
   if (!row) {
-    row = { id: (await conn.prepare(`INSERT INTO ingredients (name) VALUES (?)`).run(name)).lastInsertRowid };
+    row = { id: (await conn.prepare("INSERT INTO ingredients (name) VALUES (?)").run(name)).lastInsertRowid };
   }
   return row.id;
 }
 
 async function upsertTag(name, conn = db) {
-  let row = await conn.prepare(`SELECT id FROM tags WHERE name = ?`).get(name);
+  let row = await conn.prepare("SELECT id FROM tags WHERE name = ?").get(name);
   if (!row) {
-    row = { id: (await conn.prepare(`INSERT INTO tags (name) VALUES (?)`).run(name)).lastInsertRowid };
+    row = { id: (await conn.prepare("INSERT INTO tags (name) VALUES (?)").run(name)).lastInsertRowid };
   }
   return row.id;
 }
@@ -20,7 +20,7 @@ async function saveIngredients(recipeId, ingredients = [], conn = db) {
   for (const ing of ingredients) {
     if (!ing.name?.trim()) continue;
     const ingredientId = await upsertIngredient(ing.name, conn);
-    await conn.prepare(`INSERT INTO recipe_ingredients (recipe_id, ingredient_id, amount, unit) VALUES (?, ?, ?, ?)`)
+    await conn.prepare("INSERT INTO recipe_ingredients (recipe_id, ingredient_id, amount, unit) VALUES (?, ?, ?, ?)")
       .run(recipeId, ingredientId, ing.amount || null, ing.unit || null);
   }
 }
@@ -29,13 +29,13 @@ async function saveTags(recipeId, tags = [], conn = db) {
   for (const t of tags) {
     if (!t.name?.trim()) continue;
     const tagId = await upsertTag(t.name, conn);
-    await conn.prepare(`INSERT INTO recipe_tags (recipe_id, tag_id) VALUES (?, ?)`).run(recipeId, tagId);
+    await conn.prepare("INSERT INTO recipe_tags (recipe_id, tag_id) VALUES (?, ?)").run(recipeId, tagId);
   }
 }
 
 export async function listRecipes() {
   const recipes = await db.prepare(
-    `SELECT id, title, time_minutes, price, link, image FROM recipes`
+    "SELECT id, title, time_minutes, price, link, image FROM recipes"
   ).all();
 
   const allIngredients = await db.prepare(`
@@ -74,7 +74,7 @@ export async function listRecipes() {
 
 export async function listRecipesByCountry(country) {
   const recipes = await db.prepare(
-    `SELECT id, title, time_minutes, price, link, description, image, country FROM recipes WHERE LOWER(country) = ?`
+    "SELECT id, title, time_minutes, price, link, description, image, country FROM recipes WHERE LOWER(country) = ?"
   ).all(country.toLowerCase());
 
   const ids = recipes.map(r => r.id);
@@ -108,7 +108,7 @@ export async function listRecipesByCountry(country) {
 
 export async function getRecipe(id) {
   const recipe = await db.prepare(
-    `SELECT id, title, time_minutes, price, link, description, instructions, image FROM recipes WHERE id = ?`
+    "SELECT id, title, time_minutes, price, link, description, instructions, image FROM recipes WHERE id = ?"
   ).get(id);
 
   if (!recipe) return null;
@@ -144,7 +144,7 @@ export async function getRecipe(id) {
 export async function createRecipe(data) {
   return db.transaction(async (tx) => {
     const result = await tx.prepare(
-      `INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      "INSERT INTO recipes (title, time_minutes, price, link, description, instructions, image, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
     ).run(
       data.title.trim(),
       data.time_minutes || 0,
@@ -165,11 +165,11 @@ export async function createRecipe(data) {
 
 export async function updateRecipe(id, data) {
   return db.transaction(async (tx) => {
-    const existing = await tx.prepare(`SELECT id FROM recipes WHERE id = ?`).get(id);
+    const existing = await tx.prepare("SELECT id FROM recipes WHERE id = ?").get(id);
     if (!existing) return false;
 
     await tx.prepare(
-      `UPDATE recipes SET title = ?, time_minutes = ?, price = ?, link = ?, description = ?, instructions = ?, image = ?, country = ? WHERE id = ?`
+      "UPDATE recipes SET title = ?, time_minutes = ?, price = ?, link = ?, description = ?, instructions = ?, image = ?, country = ? WHERE id = ?"
     ).run(
       data.title.trim(),
       data.time_minutes || 0,
@@ -182,8 +182,8 @@ export async function updateRecipe(id, data) {
       id
     );
 
-    await tx.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
-    await tx.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
+    await tx.prepare("DELETE FROM recipe_ingredients WHERE recipe_id = ?").run(id);
+    await tx.prepare("DELETE FROM recipe_tags WHERE recipe_id = ?").run(id);
     await saveIngredients(id, data.ingredients, tx);
     await saveTags(id, data.tags, tx);
     return true;
@@ -192,16 +192,16 @@ export async function updateRecipe(id, data) {
 
 export async function deleteRecipe(id) {
   await db.transaction(async (tx) => {
-    await tx.prepare(`DELETE FROM recipe_ingredients WHERE recipe_id = ?`).run(id);
-    await tx.prepare(`DELETE FROM recipe_tags WHERE recipe_id = ?`).run(id);
-    await tx.prepare(`DELETE FROM recipes WHERE id = ?`).run(id);
+    await tx.prepare("DELETE FROM recipe_ingredients WHERE recipe_id = ?").run(id);
+    await tx.prepare("DELETE FROM recipe_tags WHERE recipe_id = ?").run(id);
+    await tx.prepare("DELETE FROM recipes WHERE id = ?").run(id);
   });
 }
 
 export async function listIngredients() {
-  return db.prepare(`SELECT id, name FROM ingredients`).all();
+  return db.prepare("SELECT id, name FROM ingredients").all();
 }
 
 export async function listTags() {
-  return db.prepare(`SELECT id, name FROM tags`).all();
+  return db.prepare("SELECT id, name FROM tags").all();
 }

--- a/definition-of-done.md
+++ b/definition-of-done.md
@@ -1,0 +1,62 @@
+# **Definition of Done**
+
+ **Cookbook‑projektet** er *Done* når alle krav er opfyldt.
+
+---
+
+## **1. Funktionalitet**
+- [x] Funktionalitet implementeret og matcher API‑kontrakten i `openapi.yaml`.  
+- [x] Ingen breaking changes — eksisterende endpoints fungerer fortsat.  
+- [x] Backend kører på Node.js `node:http` uden frameworks.
+
+---
+
+## **2. Database & Migration**
+- [x] Understøtter både SQLite (dev) og PostgreSQL (prod).  
+- [x] Migration gennemført uden datatab.  
+- [ ] Rollback‑plan dokumenteret.  
+- [ ] Feature branch bevaret for sporbarhed.
+
+---
+
+## **3. Kodekvalitet**
+- [ ] ESLint og Prettier passerer.  
+- [x] Ingen secrets i repo.  
+- [x] Konventionelle commits.  
+- [x] Kode er læsbar og organiseret.
+
+---
+
+## **4. Tests**
+- [x] Unit tests dækker kritisk logik.  
+- [x] Integrationstests for API endpoints.  
+- [ ] Coverage > 70%.  
+- [x] Tests kører automatisk i CI.
+
+---
+
+## **5. CI/CD**
+- [x] Build, lint og tests kører automatisk.  
+- [x] npm audit uden high severity.  
+- [x] Automatisk deployment til Azure VMs.  
+- [x] Blue/green deployment understøttet.  
+- [ ] Health checks før deploy.
+
+---
+
+## **6. Infrastruktur & Drift**
+- [x] Kører på Azure VMs.  
+- [ ] Netværk og firewall korrekt konfigureret.  
+- [ ] Monitoring aktiv (logs, metrics, alerts).  
+- [x] Health endpoint `/health` fungerer.  
+- [x] Systemet er live og tilgængeligt.
+
+---
+
+## **7. Projekt‑dokumentation**
+- [x] README opdateret med setup, run og deploy.  
+- [ ] Arkitekturdiagrammer inkluderet.  
+- [ ] Database migration dokumenteret.  
+- [x] CI/CD pipeline dokumenteret.
+
+---

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+RUN npm run lint
 RUN npm run build
 
 FROM nginx:alpine

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,49 @@
+import js from "@eslint/js";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["src/**/*.{js,jsx}"],
+    plugins: {
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        navigator: "readonly",
+        console: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        fetch: "readonly",
+        confirm: "readonly",
+        alert: "readonly",
+      },
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+    rules: {
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      "quotes": ["error", "double"],
+      "semi": ["error", "always"],
+      "indent": ["error", 2],
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "no-console": "warn",
+      "react/react-in-jsx-scope": "off",
+      // PropTypes not enforced — project does not use the prop-types library
+      "react/prop-types": "off",
+      // @react-three/fiber uses custom JSX properties (attach, args, etc.) unknown to ESLint
+      "react/no-unknown-property": "off",
+    },
+  },
+];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,11 @@
         "three": "^0.183.2"
       },
       "devDependencies": {
+        "@eslint/js": "^9.0.0",
         "@vitejs/plugin-react": "^5.0.0",
+        "eslint": "^9.0.0",
+        "eslint-plugin-react": "^7.0.0",
+        "eslint-plugin-react-hooks": "^5.0.0",
         "vite": "^6.0.0"
       }
     },
@@ -759,6 +763,216 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1336,6 +1550,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
@@ -1433,6 +1654,240 @@
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1473,6 +1928,17 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/browserslist": {
@@ -1533,6 +1999,66 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camera-controls": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
@@ -1566,6 +2092,50 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1626,6 +2196,60 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1644,6 +2268,49 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-gpu": {
       "version": "5.0.70",
       "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
@@ -1653,11 +2320,39 @@
         "webgl-constants": "^1.1.1"
       }
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/draco3d": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -1665,6 +2360,183 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1718,6 +2590,240 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1742,6 +2848,73 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1757,6 +2930,57 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1767,11 +2991,218 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/glsl-noise": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/hls.js": {
       "version": "1.6.15",
@@ -1799,11 +3230,300 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -1811,11 +3531,181 @@
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/its-fine": {
       "version": "2.0.0",
@@ -1836,6 +3726,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -1848,6 +3751,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1862,6 +3786,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -1869,6 +3833,42 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -1891,6 +3891,16 @@
         "three": ">=0.134.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -1905,6 +3915,19 @@
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
       "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
       "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1932,12 +3955,237 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -1947,6 +4195,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1966,6 +4221,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -2003,6 +4268,16 @@
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
       "license": "ISC"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -2011,6 +4286,28 @@
       "dependencies": {
         "is-promise": "^2.1.0",
         "lie": "^3.0.2"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -2033,6 +4330,13 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -2097,6 +4401,50 @@
         }
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2104,6 +4452,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rollup": {
@@ -2151,6 +4533,61 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2173,6 +4610,55 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2192,6 +4678,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/source-map-js": {
@@ -2229,6 +4791,157 @@
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/suspend-react": {
       "version": "0.1.3",
@@ -2361,6 +5074,116 @@
         }
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2390,6 +5213,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -2511,12 +5344,124 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.7",
@@ -17,7 +19,11 @@
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "eslint": "^9.0.0",
+    "eslint-plugin-react": "^7.0.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "vite": "^6.0.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,21 @@
-import { BrowserRouter, Routes, Route, Link, useNavigate } from 'react-router-dom'
-import LandingPage  from './pages/LandingPage'
-import RecipeList   from './pages/RecipeList'
-import RecipeDetail from './pages/RecipeDetail'
-import RecipeForm   from './pages/RecipeForm'
+import { BrowserRouter, Routes, Route, Link, useNavigate } from "react-router-dom";
+import LandingPage  from "./pages/LandingPage";
+import RecipeList   from "./pages/RecipeList";
+import RecipeDetail from "./pages/RecipeDetail";
+import RecipeForm   from "./pages/RecipeForm";
 
 function RecipeLayout({ children }) {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   return (
     <div className="app">
       <header className="header">
         <div className="header-inner">
-          <Link to="/" className="logo" style={{ textDecoration: 'none' }}>
+          <Link to="/" className="logo" style={{ textDecoration: "none" }}>
             ✦ Cookbook
           </Link>
           <nav>
             <Link to="/recipes" className="nav-link">Opskrifter</Link>
-            <button className="btn-primary" onClick={() => navigate('/recipes/new')}>
+            <button className="btn-primary" onClick={() => navigate("/recipes/new")}>
               + Ny opskrift
             </button>
           </nav>
@@ -23,7 +23,7 @@ function RecipeLayout({ children }) {
       </header>
       {children}
     </div>
-  )
+  );
 }
 
 export default function App() {
@@ -45,5 +45,5 @@ export default function App() {
         } />
       </Routes>
     </BrowserRouter>
-  )
+  );
 }

--- a/frontend/src/api/recipes.js
+++ b/frontend/src/api/recipes.js
@@ -1,40 +1,40 @@
-const BASE = '/api/recipe/recipes'
+const BASE = "/api/recipe/recipes";
 
 async function request(url, options) {
-  const res = await fetch(url, options)
-  if (!res.ok) throw new Error(`Request failed: ${res.status}`)
-  if (res.status === 204) return null
-  return res.json()
+  const res = await fetch(url, options);
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  if (res.status === 204) return null;
+  return res.json();
 }
 
 export function listRecipes() {
-  return request(`${BASE}/`)
+  return request(`${BASE}/`);
 }
 
 export function getRecipe(id) {
-  return request(`${BASE}/${id}/`)
+  return request(`${BASE}/${id}/`);
 }
 
 export function listRecipesByCountry(countryId) {
-  return request(`${BASE}/country/${countryId}`)
+  return request(`${BASE}/country/${countryId}`);
 }
 
 export function createRecipe(payload) {
   return request(`${BASE}/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
-  })
+  });
 }
 
 export function updateRecipe(id, payload) {
   return request(`${BASE}/${id}/`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
-  })
+  });
 }
 
 export function deleteRecipe(id) {
-  return request(`${BASE}/${id}/`, { method: 'DELETE' })
+  return request(`${BASE}/${id}/`, { method: "DELETE" });
 }

--- a/frontend/src/components/CountryPanel.jsx
+++ b/frontend/src/components/CountryPanel.jsx
@@ -1,34 +1,34 @@
-import { useEffect, useState } from 'react'
-import RecipeCard from './RecipeCard'
-import { listRecipesByCountry } from '../api/recipes'
+import { useEffect, useState } from "react";
+import RecipeCard from "./RecipeCard";
+import { listRecipesByCountry } from "../api/recipes";
 
 export default function CountryPanel({ country, onClose }) {
-  const [recipes, setRecipes]   = useState([])
-  const [loading, setLoading]   = useState(false)
-  const [error, setError]       = useState(null)
-  const isOpen = !!country
+  const [recipes, setRecipes]   = useState([]);
+  const [loading, setLoading]   = useState(false);
+  const [error, setError]       = useState(null);
+  const isOpen = !!country;
 
   useEffect(() => {
-    if (!country) return
-    setLoading(true)
-    setError(null)
-    setRecipes([])
+    if (!country) return;
+    setLoading(true);
+    setError(null);
+    setRecipes([]);
     listRecipesByCountry(country.id)
-      .then(data => { setRecipes(data); setLoading(false) })
-      .catch(() => { setError('Kunne ikke hente opskrifter.'); setLoading(false) })
-  }, [country])
+      .then(data => { setRecipes(data); setLoading(false); })
+      .catch(() => { setError("Kunne ikke hente opskrifter."); setLoading(false); });
+  }, [country]);
 
   // Close on backdrop click
   const handleBackdropClick = (e) => {
-    if (e.target === e.currentTarget) onClose()
-  }
+    if (e.target === e.currentTarget) onClose();
+  };
 
   return (
     <div
-      className={`country-panel-backdrop${isOpen ? ' open' : ''}`}
+      className={`country-panel-backdrop${isOpen ? " open" : ""}`}
       onClick={handleBackdropClick}
     >
-      <aside className={`country-panel${isOpen ? ' open' : ''}`}>
+      <aside className={`country-panel${isOpen ? " open" : ""}`}>
         <button className="panel-close" onClick={onClose} aria-label="Luk">✕</button>
 
         {country && (
@@ -37,7 +37,7 @@ export default function CountryPanel({ country, onClose }) {
               <span className="panel-flag">{country.flag}</span>
               <h2 className="panel-country-name">{country.name}</h2>
               <p className="panel-recipe-count">
-                {loading ? '…' : `${recipes.length} ${recipes.length === 1 ? 'opskrift' : 'opskrifter'}`}
+                {loading ? "…" : `${recipes.length} ${recipes.length === 1 ? "opskrift" : "opskrifter"}`}
               </p>
               <div
                 className="panel-accent"
@@ -75,5 +75,5 @@ export default function CountryPanel({ country, onClose }) {
         )}
       </aside>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/Globe.jsx
+++ b/frontend/src/components/Globe.jsx
@@ -1,9 +1,9 @@
-import { useRef, useState, useCallback, useMemo } from 'react'
-import { useFrame } from '@react-three/fiber'
-import { useTexture, OrbitControls, Html } from '@react-three/drei'
-import * as THREE from 'three'
+import { useRef, useState, useCallback, useMemo } from "react";
+import { useFrame } from "@react-three/fiber";
+import { useTexture, OrbitControls, Html } from "@react-three/drei";
+import * as THREE from "three";
 
-const RADIUS = 2.2
+const RADIUS = 2.2;
 
 export const COUNTRIES = [
   { id: "italy",    name: "Italien",  flag: "🇮🇹", lat: 42.5,  lng: 12.5,   color: "#FF4D4D" },
@@ -14,32 +14,32 @@ export const COUNTRIES = [
   { id: "india",    name: "Indien",   flag: "🇮🇳", lat: 20.6,  lng: 79.0,   color: "#FFB347" },
   { id: "morocco",  name: "Marokko",  flag: "🇲🇦", lat: 31.8,  lng: -7.1,   color: "#E85D5D" },
   { id: "thailand", name: "Thailand", flag: "🇹🇭", lat: 15.9,  lng: 100.9,  color: "#47A0FF" },
-]
+];
 
 function latLngToVector3(lat, lng, radius) {
-  const phi   = (90 - lat)  * (Math.PI / 180)
-  const theta = (lng + 180) * (Math.PI / 180)
+  const phi   = (90 - lat)  * (Math.PI / 180);
+  const theta = (lng + 180) * (Math.PI / 180);
   return new THREE.Vector3(
     -(radius * Math.sin(phi) * Math.cos(theta)),
     radius  * Math.cos(phi),
     radius  * Math.sin(phi) * Math.sin(theta)
-  )
+  );
 }
 
 function Stars() {
   const positions = useMemo(() => {
-    const count = 2200
-    const arr = new Float32Array(count * 3)
+    const count = 2200;
+    const arr = new Float32Array(count * 3);
     for (let i = 0; i < count; i++) {
-      const r     = 80 + Math.random() * 140
-      const theta = Math.random() * Math.PI * 2
-      const phi   = Math.acos(2 * Math.random() - 1)
-      arr[i * 3]     = r * Math.sin(phi) * Math.cos(theta)
-      arr[i * 3 + 1] = r * Math.cos(phi)
-      arr[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta)
+      const r     = 80 + Math.random() * 140;
+      const theta = Math.random() * Math.PI * 2;
+      const phi   = Math.acos(2 * Math.random() - 1);
+      arr[i * 3]     = r * Math.sin(phi) * Math.cos(theta);
+      arr[i * 3 + 1] = r * Math.cos(phi);
+      arr[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
     }
-    return arr
-  }, [])
+    return arr;
+  }, []);
   return (
     <points>
       <bufferGeometry>
@@ -47,7 +47,7 @@ function Stars() {
       </bufferGeometry>
       <pointsMaterial size={0.16} color="#b8d4ff" transparent opacity={0.7} sizeAttenuation />
     </points>
-  )
+  );
 }
 
 function Atmosphere() {
@@ -62,87 +62,87 @@ function Atmosphere() {
         <meshBasicMaterial color="#0d3a8a" transparent opacity={0.05} side={THREE.BackSide} depthWrite={false} />
       </mesh>
     </>
-  )
+  );
 }
 
 function CountryMarker({ country, onClick }) {
-  const groupRef  = useRef()
-  const pulseRef  = useRef()
-  const dotRef    = useRef()
-  const [hovered, setHovered] = useState(false)
-  const [visible, setVisible] = useState(true)
-  const visibleRef = useRef(true)
-  const clickTime  = useRef(0)
+  const groupRef  = useRef();
+  const pulseRef  = useRef();
+  const dotRef    = useRef();
+  const [hovered, setHovered] = useState(false);
+  const [visible, setVisible] = useState(true);
+  const visibleRef = useRef(true);
+  const clickTime  = useRef(0);
 
   const pos = useMemo(
     () => latLngToVector3(country.lat, country.lng, RADIUS + 0.02),
     [country.lat, country.lng]
-  )
+  );
 
   // Quaternion that orients the flat XY geometries to face outward from the sphere
   const quat = useMemo(() => {
-    const normal = pos.clone().normalize()
+    const normal = pos.clone().normalize();
     return new THREE.Quaternion().setFromUnitVectors(
       new THREE.Vector3(0, 0, 1),
       normal
-    )
-  }, [pos])
+    );
+  }, [pos]);
 
-  const color = useMemo(() => new THREE.Color(country.color), [country.color])
+  const color = useMemo(() => new THREE.Color(country.color), [country.color]);
 
   // Pre-allocate vectors to avoid GC pressure in the render loop
-  const tempVec = useMemo(() => new THREE.Vector3(), [])
-  const camDirVec = useMemo(() => new THREE.Vector3(), [])
+  const tempVec = useMemo(() => new THREE.Vector3(), []);
+  const camDirVec = useMemo(() => new THREE.Vector3(), []);
 
   useFrame(({ camera, clock }) => {
-    const t = clock.getElapsedTime()
+    const t = clock.getElapsedTime();
 
     // Hide label + fade marker when on the far side of the globe
     if (groupRef.current) {
-      groupRef.current.getWorldPosition(tempVec)
-      camDirVec.copy(camera.position).normalize()
-      tempVec.normalize()
-      const isVisible = camDirVec.dot(tempVec) > 0.05
+      groupRef.current.getWorldPosition(tempVec);
+      camDirVec.copy(camera.position).normalize();
+      tempVec.normalize();
+      const isVisible = camDirVec.dot(tempVec) > 0.05;
       if (visibleRef.current !== isVisible) {
-        visibleRef.current = isVisible
-        setVisible(isVisible)
+        visibleRef.current = isVisible;
+        setVisible(isVisible);
       }
     }
 
     // Pulse ring animation
     if (pulseRef.current) {
-      const s = 1 + 0.85 * Math.abs(Math.sin(t * 1.4))
-      pulseRef.current.scale.setScalar(s)
-      pulseRef.current.material.opacity = 0.5 * (1 - Math.abs(Math.sin(t * 1.4)))
+      const s = 1 + 0.85 * Math.abs(Math.sin(t * 1.4));
+      pulseRef.current.scale.setScalar(s);
+      pulseRef.current.material.opacity = 0.5 * (1 - Math.abs(Math.sin(t * 1.4)));
     }
 
     // Dot breathing + click pop
     if (dotRef.current) {
-      const elapsed = Date.now() - clickTime.current
-      let scale = 1 + 0.12 * Math.sin(t * 2.5)
-      if (hovered) scale *= 1.5
-      if (elapsed < 300) scale *= 1 + 0.8 * (1 - elapsed / 300)
-      dotRef.current.scale.setScalar(scale)
+      const elapsed = Date.now() - clickTime.current;
+      let scale = 1 + 0.12 * Math.sin(t * 2.5);
+      if (hovered) scale *= 1.5;
+      if (elapsed < 300) scale *= 1 + 0.8 * (1 - elapsed / 300);
+      dotRef.current.scale.setScalar(scale);
     }
-  })
+  });
 
   const handleClick = useCallback((e) => {
-    e.stopPropagation()
-    clickTime.current = Date.now()
-    onClick(country)
-  }, [country, onClick])
+    e.stopPropagation();
+    clickTime.current = Date.now();
+    onClick(country);
+  }, [country, onClick]);
 
   const handlePointerOver = useCallback((e) => {
-    e.stopPropagation()
-    setHovered(true)
-    document.body.style.cursor = 'pointer'
-  }, [])
+    e.stopPropagation();
+    setHovered(true);
+    document.body.style.cursor = "pointer";
+  }, []);
 
   const handlePointerOut = useCallback((e) => {
-    e.stopPropagation()
-    setHovered(false)
-    document.body.style.cursor = 'auto'
-  }, [])
+    e.stopPropagation();
+    setHovered(false);
+    document.body.style.cursor = "auto";
+  }, []);
 
   return (
     <group
@@ -187,7 +187,7 @@ function CountryMarker({ country, onClick }) {
         <Html
           position={[0, 0, 0.04]}
           center
-          style={{ pointerEvents: 'none', whiteSpace: 'nowrap', userSelect: 'none' }}
+          style={{ pointerEvents: "none", whiteSpace: "nowrap", userSelect: "none" }}
         >
           <div className="globe-label" style={{ borderColor: `${country.color}33` }}>
             <span className="globe-label-flag">{country.flag}</span>
@@ -196,22 +196,22 @@ function CountryMarker({ country, onClick }) {
         </Html>
       )}
     </group>
-  )
+  );
 }
 
 export default function Globe({ onCountryClick }) {
-  const rotGroupRef = useRef()
-  const [autoRotate, setAutoRotate] = useState(true)
+  const rotGroupRef = useRef();
+  const [autoRotate, setAutoRotate] = useState(true);
 
-  const colorMap = useTexture('/textures/world.200407.3x5400x2700.jpg')
+  const colorMap = useTexture("/textures/world.200407.3x5400x2700.jpg");
 
   useFrame((_, delta) => {
     if (autoRotate && rotGroupRef.current) {
-      rotGroupRef.current.rotation.y += delta * 0.07
+      rotGroupRef.current.rotation.y += delta * 0.07;
     }
-  })
+  });
 
-  const handleStart = useCallback(() => setAutoRotate(false), [])
+  const handleStart = useCallback(() => setAutoRotate(false), []);
 
   return (
     <>
@@ -246,5 +246,5 @@ export default function Globe({ onCountryClick }) {
 
       <Atmosphere />
     </>
-  )
+  );
 }

--- a/frontend/src/components/RecipeCard.jsx
+++ b/frontend/src/components/RecipeCard.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from "react-router-dom";
 
 export default function RecipeCard({ recipe }) {
   return (
@@ -21,5 +21,5 @@ export default function RecipeCard({ recipe }) {
         </div>
       </div>
     </Link>
-  )
+  );
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './styles/app.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./styles/app.css";
+import App from "./App.jsx";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <App />
   </StrictMode>
-)
+);

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -76,17 +76,17 @@ export default function LandingPage() {
             <span className="continent-label">{group.continent}</span>
             <div className="continent-buttons">
               {group.ids.map(id => {
-                const c = COUNTRIES.find(x => x.id === id)
+                const c = COUNTRIES.find(x => x.id === id);
                 return (
                   <button
                     key={c.id}
-                    className={`country-btn${selectedCountry?.id === c.id ? ' active' : ''}`}
+                    className={`country-btn${selectedCountry?.id === c.id ? " active" : ""}`}
                     onClick={() => handleCountryClick(c)}
                   >
                     <span className="country-btn-flag">{c.flag}</span>
                     {c.name}
                   </button>
-                )
+                );
               })}
             </div>
           </div>
@@ -96,5 +96,5 @@ export default function LandingPage() {
       {/* Slide-in panel */}
       <CountryPanel country={selectedCountry} onClose={handleClosePanel} />
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, Suspense } from 'react'
-import { Canvas } from '@react-three/fiber'
-import { Link } from 'react-router-dom'
-import Globe, { COUNTRIES } from '../components/Globe'
-import CountryPanel from '../components/CountryPanel'
-import '../styles/landing.css'
+import { useState, useEffect, Suspense } from "react";
+import { Canvas } from "@react-three/fiber";
+import { Link } from "react-router-dom";
+import Globe, { COUNTRIES } from "../components/Globe";
+import CountryPanel from "../components/CountryPanel";
+import "../styles/landing.css";
 
 function GlobeLoader() {
   return (
@@ -11,21 +11,21 @@ function GlobeLoader() {
       <sphereGeometry args={[2.2, 32, 32]} />
       <meshBasicMaterial color="#0a1830" wireframe />
     </mesh>
-  )
+  );
 }
 
 export default function LandingPage() {
-  const [selectedCountry, setSelectedCountry]   = useState(null)
-  const [showIntro, setShowIntro]               = useState(true)
+  const [selectedCountry, setSelectedCountry]   = useState(null);
+  const [showIntro, setShowIntro]               = useState(true);
 
   // Hide intro text after animation completes (3 s)
   useEffect(() => {
-    const t = setTimeout(() => setShowIntro(false), 3100)
-    return () => clearTimeout(t)
-  }, [])
+    const t = setTimeout(() => setShowIntro(false), 3100);
+    return () => clearTimeout(t);
+  }, []);
 
-  const handleCountryClick = (country) => setSelectedCountry(country)
-  const handleClosePanel   = ()        => setSelectedCountry(null)
+  const handleCountryClick = (country) => setSelectedCountry(country);
+  const handleClosePanel   = ()        => setSelectedCountry(null);
 
   return (
     <div className="landing">

--- a/frontend/src/pages/RecipeDetail.jsx
+++ b/frontend/src/pages/RecipeDetail.jsx
@@ -1,49 +1,49 @@
-import { useState, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
-import { getRecipe, deleteRecipe } from '../api/recipes'
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getRecipe, deleteRecipe } from "../api/recipes";
 
 export default function RecipeDetail() {
-  const { id }       = useParams()
-  const navigate     = useNavigate()
-  const [recipe, setRecipe]   = useState(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError]     = useState(null)
+  const { id }       = useParams();
+  const navigate     = useNavigate();
+  const [recipe, setRecipe]   = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
 
   useEffect(() => {
-    setLoading(true)
+    setLoading(true);
     getRecipe(id)
-      .then(data => { setRecipe(data); setLoading(false) })
-      .catch(() => { setError('Kunne ikke hente opskrift.'); setLoading(false) })
-  }, [id])
+      .then(data => { setRecipe(data); setLoading(false); })
+      .catch(() => { setError("Kunne ikke hente opskrift."); setLoading(false); });
+  }, [id]);
 
   const handleDelete = async () => {
-    if (!confirm(`Slet "${recipe.title}"?`)) return
+    if (!confirm(`Slet "${recipe.title}"?`)) return;
     try {
-      await deleteRecipe(id)
-      navigate('/recipes')
+      await deleteRecipe(id);
+      navigate("/recipes");
     } catch {
-      setError('Kunne ikke slette opskriften. Prøv igen.')
+      setError("Kunne ikke slette opskriften. Prøv igen.");
     }
-  }
+  };
 
   if (loading) return (
     <main className="main">
       <div className="loading"><div className="spinner" /> Henter…</div>
     </main>
-  )
+  );
 
   if (error) return (
     <main className="main">
-      <button className="back-btn" onClick={() => navigate('/recipes')}>← Tilbage</button>
+      <button className="back-btn" onClick={() => navigate("/recipes")}>← Tilbage</button>
       <div className="error-msg">{error}</div>
     </main>
-  )
+  );
 
-  const steps = Array.isArray(recipe.instructions) ? recipe.instructions : []
+  const steps = Array.isArray(recipe.instructions) ? recipe.instructions : [];
 
   return (
     <main className="main">
-      <button className="back-btn" onClick={() => navigate('/recipes')}>← Alle opskrifter</button>
+      <button className="back-btn" onClick={() => navigate("/recipes")}>← Alle opskrifter</button>
 
       {recipe.image && (
         <div className="detail-image">
@@ -59,7 +59,7 @@ export default function RecipeDetail() {
       </div>
 
       {recipe.tags?.length > 0 && (
-        <div className="card-tags" style={{ marginBottom: '1.5rem' }}>
+        <div className="card-tags" style={{ marginBottom: "1.5rem" }}>
           {recipe.tags.map(t => <span key={t.id} className="tag">{t.name}</span>)}
         </div>
       )}
@@ -113,5 +113,5 @@ export default function RecipeDetail() {
         )}
       </div>
     </main>
-  )
+  );
 }

--- a/frontend/src/pages/RecipeForm.jsx
+++ b/frontend/src/pages/RecipeForm.jsx
@@ -1,75 +1,75 @@
-import { useState, useEffect } from 'react'
-import { useNavigate, useLocation, useParams } from 'react-router-dom'
-import { getRecipe, createRecipe, updateRecipe } from '../api/recipes'
+import { useState, useEffect } from "react";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
+import { getRecipe, createRecipe, updateRecipe } from "../api/recipes";
 
 const EMPTY = {
-  title: '', description: '', time_minutes: '', price: '', link: '', image: '',
-  ingredients: [{ name: '', amount: '', unit: '' }],
-  tags: [{ name: '' }],
-  instructions: [''],
-}
+  title: "", description: "", time_minutes: "", price: "", link: "", image: "",
+  ingredients: [{ name: "", amount: "", unit: "" }],
+  tags: [{ name: "" }],
+  instructions: [""],
+};
 
 function toForm(recipe) {
-  if (!recipe) return EMPTY
+  if (!recipe) return EMPTY;
   return {
-    title: recipe.title || '',
-    description: recipe.description || '',
-    time_minutes: recipe.time_minutes ?? '',
-    price: recipe.price ?? '',
-    link: recipe.link || '',
-    image: recipe.image || '',
+    title: recipe.title || "",
+    description: recipe.description || "",
+    time_minutes: recipe.time_minutes ?? "",
+    price: recipe.price ?? "",
+    link: recipe.link || "",
+    image: recipe.image || "",
     ingredients: recipe.ingredients?.length
-      ? recipe.ingredients.map(i => ({ name: i.name, amount: i.amount ?? '', unit: i.unit ?? '' }))
-      : [{ name: '', amount: '', unit: '' }],
-    tags: recipe.tags?.length ? recipe.tags.map(t => ({ name: t.name })) : [{ name: '' }],
-    instructions: recipe.instructions?.length ? recipe.instructions : [''],
-  }
+      ? recipe.ingredients.map(i => ({ name: i.name, amount: i.amount ?? "", unit: i.unit ?? "" }))
+      : [{ name: "", amount: "", unit: "" }],
+    tags: recipe.tags?.length ? recipe.tags.map(t => ({ name: t.name })) : [{ name: "" }],
+    instructions: recipe.instructions?.length ? recipe.instructions : [""],
+  };
 }
 
 export default function RecipeForm() {
-  const navigate    = useNavigate()
-  const location    = useLocation()
-  const { id }      = useParams()
-  const isEdit      = !!id
+  const navigate    = useNavigate();
+  const location    = useLocation();
+  const { id }      = useParams();
+  const isEdit      = !!id;
 
-  const [form, setForm]       = useState(() => toForm(location.state?.recipe ?? null))
-  const [saving, setSaving]   = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [error, setError]     = useState(null)
+  const [form, setForm]       = useState(() => toForm(location.state?.recipe ?? null));
+  const [saving, setSaving]   = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError]     = useState(null);
 
-  // If editing but no recipe in location state (e.g. page refresh), fetch from API
+  // If editing but no recipe in location state (e.g page refresh), fetch from API
   useEffect(() => {
     if (isEdit && !location.state?.recipe) {
-      setLoading(true)
+      setLoading(true);
       getRecipe(id)
-        .then(data => { setForm(toForm(data)); setLoading(false) })
-        .catch(() => { setError('Kunne ikke hente opskriften.'); setLoading(false) })
+        .then(data => { setForm(toForm(data)); setLoading(false); })
+        .catch(() => { setError("Kunne ikke hente opskriften."); setLoading(false); });
     }
-  }, [id, isEdit, location.state])
+  }, [id, isEdit, location.state]);
 
-  const set = (field, val) => setForm(f => ({ ...f, [field]: val }))
+  const set = (field, val) => setForm(f => ({ ...f, [field]: val }));
 
   const updateIng = (i, field, val) => {
-    const next = [...form.ingredients]; next[i] = { ...next[i], [field]: val }; set('ingredients', next)
-  }
-  const addIng    = ()  => set('ingredients', [...form.ingredients, { name: '', amount: '', unit: '' }])
-  const removeIng = (i) => set('ingredients', form.ingredients.filter((_, idx) => idx !== i))
+    const next = [...form.ingredients]; next[i] = { ...next[i], [field]: val }; set("ingredients", next);
+  };
+  const addIng    = ()  => set("ingredients", [...form.ingredients, { name: "", amount: "", unit: "" }]);
+  const removeIng = (i) => set("ingredients", form.ingredients.filter((_, idx) => idx !== i));
 
   const updateTag = (i, val) => {
-    const next = [...form.tags]; next[i] = { name: val }; set('tags', next)
-  }
-  const addTag    = ()  => set('tags', [...form.tags, { name: '' }])
-  const removeTag = (i) => set('tags', form.tags.filter((_, idx) => idx !== i))
+    const next = [...form.tags]; next[i] = { name: val }; set("tags", next);
+  };
+  const addTag    = ()  => set("tags", [...form.tags, { name: "" }]);
+  const removeTag = (i) => set("tags", form.tags.filter((_, idx) => idx !== i));
 
   const updateStep = (i, val) => {
-    const next = [...form.instructions]; next[i] = val; set('instructions', next)
-  }
-  const addStep    = ()  => set('instructions', [...form.instructions, ''])
-  const removeStep = (i) => set('instructions', form.instructions.filter((_, idx) => idx !== i))
+    const next = [...form.instructions]; next[i] = val; set("instructions", next);
+  };
+  const addStep    = ()  => set("instructions", [...form.instructions, ""]);
+  const removeStep = (i) => set("instructions", form.instructions.filter((_, idx) => idx !== i));
 
   const handleSubmit = async () => {
-    if (!form.title.trim()) { setError('Opskriften skal have et navn.'); return }
-    setSaving(true); setError(null)
+    if (!form.title.trim()) { setError("Opskriften skal have et navn."); return; }
+    setSaving(true); setError(null);
 
     const payload = {
       title: form.title,
@@ -79,39 +79,39 @@ export default function RecipeForm() {
       link: form.link,
       image: form.image || null,
       ingredients: form.ingredients.filter(i => i.name.trim()).map(i => ({
-        name: i.name, amount: i.amount || null, unit: i.unit || null
+        name: i.name, amount: i.amount || null, unit: i.unit || null,
       })),
       tags: form.tags.filter(t => t.name.trim()),
       instructions: form.instructions.filter(s => s.trim()),
-    }
+    };
 
     try {
       const saved = isEdit
         ? await updateRecipe(id, payload)
-        : await createRecipe(payload)
-      navigate(`/recipes/${saved.id || id}`)
+        : await createRecipe(payload);
+      navigate(`/recipes/${saved.id || id}`);
     } catch {
-      setError('Kunne ikke gemme opskriften. Prøv igen.')
-      setSaving(false)
+      setError("Kunne ikke gemme opskriften. Prøv igen.");
+      setSaving(false);
     }
-  }
+  };
 
   const handleCancel = () => {
-    if (isEdit) navigate(`/recipes/${id}`)
-    else navigate('/recipes')
-  }
+    if (isEdit) navigate(`/recipes/${id}`);
+    else navigate("/recipes");
+  };
 
   return (
     <main className="main">
       <button className="back-btn" onClick={handleCancel}>
-        ← {isEdit ? 'Tilbage til opskrift' : 'Tilbage'}
+        ← {isEdit ? "Tilbage til opskrift" : "Tilbage"}
       </button>
 
       <div className="page-header">
-        <h1 className="page-title">{isEdit ? 'Rediger opskrift' : 'Ny opskrift'}</h1>
+        <h1 className="page-title">{isEdit ? "Rediger opskrift" : "Ny opskrift"}</h1>
       </div>
 
-      {error && <div className="error-msg" style={{ marginBottom: '1.5rem' }}>{error}</div>}
+      {error && <div className="error-msg" style={{ marginBottom: "1.5rem" }}>{error}</div>}
 
       {loading ? (
         <div className="loading"><div className="spinner" /> Henter opskrift…</div>
@@ -123,34 +123,34 @@ export default function RecipeForm() {
           <div className="form-group">
             <label>Navn *</label>
             <input type="text" placeholder="f.eks. Spaghetti Carbonara"
-              value={form.title} onChange={e => set('title', e.target.value)} />
+              value={form.title} onChange={e => set("title", e.target.value)} />
           </div>
           <div className="form-group">
             <label>Beskrivelse</label>
             <textarea placeholder="Kort beskrivelse…"
-              value={form.description} onChange={e => set('description', e.target.value)} />
+              value={form.description} onChange={e => set("description", e.target.value)} />
           </div>
           <div className="form-row">
             <div className="form-group">
               <label>Tid (minutter)</label>
               <input type="number" placeholder="30"
-                value={form.time_minutes} onChange={e => set('time_minutes', e.target.value)} />
+                value={form.time_minutes} onChange={e => set("time_minutes", e.target.value)} />
             </div>
             <div className="form-group">
               <label>Pris (kr)</label>
               <input type="text" placeholder="45.00"
-                value={form.price} onChange={e => set('price', e.target.value)} />
+                value={form.price} onChange={e => set("price", e.target.value)} />
             </div>
           </div>
           <div className="form-group">
             <label>Link til kilde</label>
             <input type="text" placeholder="https://…"
-              value={form.link} onChange={e => set('link', e.target.value)} />
+              value={form.link} onChange={e => set("link", e.target.value)} />
           </div>
           <div className="form-group">
             <label>Billed-URL</label>
             <input type="text" placeholder="https://… (link til et billede)"
-              value={form.image} onChange={e => set('image', e.target.value)} />
+              value={form.image} onChange={e => set("image", e.target.value)} />
             {form.image && (
               <img src={form.image} alt="Forhåndsvisning" className="image-preview" />
             )}
@@ -163,11 +163,11 @@ export default function RecipeForm() {
             {form.ingredients.map((ing, i) => (
               <div key={i} className="ingredient-row">
                 <input type="text" placeholder="Navn" value={ing.name}
-                  onChange={e => updateIng(i, 'name', e.target.value)} />
+                  onChange={e => updateIng(i, "name", e.target.value)} />
                 <input type="text" placeholder="Mængde" value={ing.amount}
-                  onChange={e => updateIng(i, 'amount', e.target.value)} />
+                  onChange={e => updateIng(i, "amount", e.target.value)} />
                 <input type="text" placeholder="Enhed" value={ing.unit}
-                  onChange={e => updateIng(i, 'unit', e.target.value)} />
+                  onChange={e => updateIng(i, "unit", e.target.value)} />
                 <button className="btn-remove" onClick={() => removeIng(i)}
                   disabled={form.ingredients.length === 1}>×</button>
               </div>
@@ -181,7 +181,7 @@ export default function RecipeForm() {
           <div className="dynamic-list">
             {form.instructions.map((step, i) => (
               <div key={i} className="dynamic-item">
-                <span style={{ color: 'var(--text-muted)', fontSize: '0.8rem', minWidth: 20 }}>{i + 1}.</span>
+                <span style={{ color: "var(--text-muted)", fontSize: "0.8rem", minWidth: 20 }}>{i + 1}.</span>
                 <textarea placeholder={`Trin ${i + 1}…`} value={step}
                   onChange={e => updateStep(i, e.target.value)} style={{ minHeight: 60 }} />
                 <button className="btn-remove" onClick={() => removeStep(i)}
@@ -210,11 +210,11 @@ export default function RecipeForm() {
         <div className="form-actions">
           <button className="btn-secondary" onClick={handleCancel}>Annullér</button>
           <button className="btn-primary" onClick={handleSubmit} disabled={saving}>
-            {saving ? 'Gemmer…' : isEdit ? 'Gem ændringer' : 'Opret opskrift'}
+            {saving ? "Gemmer…" : isEdit ? "Gem ændringer" : "Opret opskrift"}
           </button>
         </div>
       </div>
       )}
     </main>
-  )
+  );
 }

--- a/frontend/src/pages/RecipeForm.jsx
+++ b/frontend/src/pages/RecipeForm.jsx
@@ -116,104 +116,104 @@ export default function RecipeForm() {
       {loading ? (
         <div className="loading"><div className="spinner" /> Henter opskrift…</div>
       ) : (
-      <div className="form-card">
+        <div className="form-card">
 
-        <div className="form-section">
-          <h2 className="form-section-title">Grundoplysninger</h2>
-          <div className="form-group">
-            <label>Navn *</label>
-            <input type="text" placeholder="f.eks. Spaghetti Carbonara"
-              value={form.title} onChange={e => set("title", e.target.value)} />
-          </div>
-          <div className="form-group">
-            <label>Beskrivelse</label>
-            <textarea placeholder="Kort beskrivelse…"
-              value={form.description} onChange={e => set("description", e.target.value)} />
-          </div>
-          <div className="form-row">
+          <div className="form-section">
+            <h2 className="form-section-title">Grundoplysninger</h2>
             <div className="form-group">
-              <label>Tid (minutter)</label>
-              <input type="number" placeholder="30"
-                value={form.time_minutes} onChange={e => set("time_minutes", e.target.value)} />
+              <label>Navn *</label>
+              <input type="text" placeholder="f.eks. Spaghetti Carbonara"
+                value={form.title} onChange={e => set("title", e.target.value)} />
             </div>
             <div className="form-group">
-              <label>Pris (kr)</label>
-              <input type="text" placeholder="45.00"
-                value={form.price} onChange={e => set("price", e.target.value)} />
+              <label>Beskrivelse</label>
+              <textarea placeholder="Kort beskrivelse…"
+                value={form.description} onChange={e => set("description", e.target.value)} />
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>Tid (minutter)</label>
+                <input type="number" placeholder="30"
+                  value={form.time_minutes} onChange={e => set("time_minutes", e.target.value)} />
+              </div>
+              <div className="form-group">
+                <label>Pris (kr)</label>
+                <input type="text" placeholder="45.00"
+                  value={form.price} onChange={e => set("price", e.target.value)} />
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Link til kilde</label>
+              <input type="text" placeholder="https://…"
+                value={form.link} onChange={e => set("link", e.target.value)} />
+            </div>
+            <div className="form-group">
+              <label>Billed-URL</label>
+              <input type="text" placeholder="https://… (link til et billede)"
+                value={form.image} onChange={e => set("image", e.target.value)} />
+              {form.image && (
+                <img src={form.image} alt="Forhåndsvisning" className="image-preview" />
+              )}
             </div>
           </div>
-          <div className="form-group">
-            <label>Link til kilde</label>
-            <input type="text" placeholder="https://…"
-              value={form.link} onChange={e => set("link", e.target.value)} />
-          </div>
-          <div className="form-group">
-            <label>Billed-URL</label>
-            <input type="text" placeholder="https://… (link til et billede)"
-              value={form.image} onChange={e => set("image", e.target.value)} />
-            {form.image && (
-              <img src={form.image} alt="Forhåndsvisning" className="image-preview" />
-            )}
-          </div>
-        </div>
 
-        <div className="form-section">
-          <h2 className="form-section-title">Ingredienser</h2>
-          <div className="dynamic-list">
-            {form.ingredients.map((ing, i) => (
-              <div key={i} className="ingredient-row">
-                <input type="text" placeholder="Navn" value={ing.name}
-                  onChange={e => updateIng(i, "name", e.target.value)} />
-                <input type="text" placeholder="Mængde" value={ing.amount}
-                  onChange={e => updateIng(i, "amount", e.target.value)} />
-                <input type="text" placeholder="Enhed" value={ing.unit}
-                  onChange={e => updateIng(i, "unit", e.target.value)} />
-                <button className="btn-remove" onClick={() => removeIng(i)}
-                  disabled={form.ingredients.length === 1}>×</button>
-              </div>
-            ))}
+          <div className="form-section">
+            <h2 className="form-section-title">Ingredienser</h2>
+            <div className="dynamic-list">
+              {form.ingredients.map((ing, i) => (
+                <div key={i} className="ingredient-row">
+                  <input type="text" placeholder="Navn" value={ing.name}
+                    onChange={e => updateIng(i, "name", e.target.value)} />
+                  <input type="text" placeholder="Mængde" value={ing.amount}
+                    onChange={e => updateIng(i, "amount", e.target.value)} />
+                  <input type="text" placeholder="Enhed" value={ing.unit}
+                    onChange={e => updateIng(i, "unit", e.target.value)} />
+                  <button className="btn-remove" onClick={() => removeIng(i)}
+                    disabled={form.ingredients.length === 1}>×</button>
+                </div>
+              ))}
+            </div>
+            <button className="btn-add" onClick={addIng}>+ Tilføj ingrediens</button>
           </div>
-          <button className="btn-add" onClick={addIng}>+ Tilføj ingrediens</button>
-        </div>
 
-        <div className="form-section">
-          <h2 className="form-section-title">Fremgangsmåde</h2>
-          <div className="dynamic-list">
-            {form.instructions.map((step, i) => (
-              <div key={i} className="dynamic-item">
-                <span style={{ color: "var(--text-muted)", fontSize: "0.8rem", minWidth: 20 }}>{i + 1}.</span>
-                <textarea placeholder={`Trin ${i + 1}…`} value={step}
-                  onChange={e => updateStep(i, e.target.value)} style={{ minHeight: 60 }} />
-                <button className="btn-remove" onClick={() => removeStep(i)}
-                  disabled={form.instructions.length === 1}>×</button>
-              </div>
-            ))}
+          <div className="form-section">
+            <h2 className="form-section-title">Fremgangsmåde</h2>
+            <div className="dynamic-list">
+              {form.instructions.map((step, i) => (
+                <div key={i} className="dynamic-item">
+                  <span style={{ color: "var(--text-muted)", fontSize: "0.8rem", minWidth: 20 }}>{i + 1}.</span>
+                  <textarea placeholder={`Trin ${i + 1}…`} value={step}
+                    onChange={e => updateStep(i, e.target.value)} style={{ minHeight: 60 }} />
+                  <button className="btn-remove" onClick={() => removeStep(i)}
+                    disabled={form.instructions.length === 1}>×</button>
+                </div>
+              ))}
+            </div>
+            <button className="btn-add" onClick={addStep}>+ Tilføj trin</button>
           </div>
-          <button className="btn-add" onClick={addStep}>+ Tilføj trin</button>
-        </div>
 
-        <div className="form-section">
-          <h2 className="form-section-title">Tags</h2>
-          <div className="dynamic-list">
-            {form.tags.map((tag, i) => (
-              <div key={i} className="dynamic-item">
-                <input type="text" placeholder="f.eks. italiensk" value={tag.name}
-                  onChange={e => updateTag(i, e.target.value)} />
-                <button className="btn-remove" onClick={() => removeTag(i)}
-                  disabled={form.tags.length === 1}>×</button>
-              </div>
-            ))}
+          <div className="form-section">
+            <h2 className="form-section-title">Tags</h2>
+            <div className="dynamic-list">
+              {form.tags.map((tag, i) => (
+                <div key={i} className="dynamic-item">
+                  <input type="text" placeholder="f.eks. italiensk" value={tag.name}
+                    onChange={e => updateTag(i, e.target.value)} />
+                  <button className="btn-remove" onClick={() => removeTag(i)}
+                    disabled={form.tags.length === 1}>×</button>
+                </div>
+              ))}
+            </div>
+            <button className="btn-add" onClick={addTag}>+ Tilføj tag</button>
           </div>
-          <button className="btn-add" onClick={addTag}>+ Tilføj tag</button>
-        </div>
 
-        <div className="form-actions">
-          <button className="btn-secondary" onClick={handleCancel}>Annullér</button>
-          <button className="btn-primary" onClick={handleSubmit} disabled={saving}>
-            {saving ? "Gemmer…" : isEdit ? "Gem ændringer" : "Opret opskrift"}
-          </button>
+          <div className="form-actions">
+            <button className="btn-secondary" onClick={handleCancel}>Annullér</button>
+            <button className="btn-primary" onClick={handleSubmit} disabled={saving}>
+              {saving ? "Gemmer…" : isEdit ? "Gem ændringer" : "Opret opskrift"}
+            </button>
+          </div>
         </div>
-      </div>
       )}
     </main>
   );

--- a/frontend/src/pages/RecipeList.jsx
+++ b/frontend/src/pages/RecipeList.jsx
@@ -133,8 +133,7 @@ export default function RecipeList() {
             </div>
           ))}
         </div>
-      );
-    }
+      )}
     </main>
-  )
+  );
 }

--- a/frontend/src/pages/RecipeList.jsx
+++ b/frontend/src/pages/RecipeList.jsx
@@ -1,38 +1,38 @@
-import { useState, useEffect, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { listRecipes } from '../api/recipes'
+import { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { listRecipes } from "../api/recipes";
 
 export default function RecipeList() {
-  const navigate = useNavigate()
-  const [recipes, setRecipes]     = useState([])
-  const [loading, setLoading]     = useState(true)
-  const [error, setError]         = useState(null)
-  const [search, setSearch]       = useState('')
-  const [activeTag, setActiveTag] = useState(null)
+  const navigate = useNavigate();
+  const [recipes, setRecipes]     = useState([]);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [search, setSearch]       = useState("");
+  const [activeTag, setActiveTag] = useState(null);
 
   useEffect(() => {
     listRecipes()
-      .then(data => { setRecipes(data); setLoading(false) })
-      .catch(() => { setError('Kunne ikke hente opskrifter.'); setLoading(false) })
-  }, [])
+      .then(data => { setRecipes(data); setLoading(false); })
+      .catch(() => { setError("Kunne ikke hente opskrifter."); setLoading(false); });
+  }, []);
 
   const allTags = useMemo(() => {
-    const set = new Set()
-    recipes.forEach(r => r.tags?.forEach(t => set.add(t.name)))
-    return [...set].sort()
-  }, [recipes])
+    const set = new Set();
+    recipes.forEach(r => r.tags?.forEach(t => set.add(t.name)));
+    return [...set].sort();
+  }, [recipes]);
 
   const filtered = recipes.filter(r => {
     const matchesSearch =
       r.title.toLowerCase().includes(search.toLowerCase()) ||
-      r.tags?.some(t => t.name.toLowerCase().includes(search.toLowerCase()))
-    const matchesTag = !activeTag || r.tags?.some(t => t.name === activeTag)
-    return matchesSearch && matchesTag
-  })
+      r.tags?.some(t => t.name.toLowerCase().includes(search.toLowerCase()));
+    const matchesTag = !activeTag || r.tags?.some(t => t.name === activeTag);
+    return matchesSearch && matchesTag;
+  });
 
   return (
     <main className="main">
-      <button className="back-btn" onClick={() => navigate('/')}>
+      <button className="back-btn" onClick={() => navigate("/")}>
         ← Verdenskøkkenet
       </button>
 
@@ -40,7 +40,7 @@ export default function RecipeList() {
         <h1 className="section-title-lg">Alle opskrifter</h1>
         {!loading && (
           <span className="section-count">
-            {filtered.length} {filtered.length === 1 ? 'opskrift' : 'opskrifter'}
+            {filtered.length} {filtered.length === 1 ? "opskrift" : "opskrifter"}
           </span>
         )}
       </div>
@@ -57,7 +57,7 @@ export default function RecipeList() {
         {allTags.length > 0 && (
           <div className="tag-filters">
             <button
-              className={`tag-filter-btn${!activeTag ? ' active' : ''}`}
+              className={`tag-filter-btn${!activeTag ? " active" : ""}`}
               onClick={() => setActiveTag(null)}
             >
               Alle
@@ -65,7 +65,7 @@ export default function RecipeList() {
             {allTags.map(tag => (
               <button
                 key={tag}
-                className={`tag-filter-btn${activeTag === tag ? ' active' : ''}`}
+                className={`tag-filter-btn${activeTag === tag ? " active" : ""}`}
                 onClick={() => setActiveTag(activeTag === tag ? null : tag)}
               >
                 {tag}
@@ -81,8 +81,8 @@ export default function RecipeList() {
       {!loading && !error && filtered.length === 0 && (
         <div className="empty">
           <div className="empty-icon">🍽</div>
-          <h3>{search || activeTag ? 'Ingen resultater' : 'Ingen opskrifter endnu'}</h3>
-          <p>{search || activeTag ? 'Prøv et andet søgeord eller filter' : 'Tilføj din første opskrift!'}</p>
+          <h3>{search || activeTag ? "Ingen resultater" : "Ingen opskrifter endnu"}</h3>
+          <p>{search || activeTag ? "Prøv et andet søgeord eller filter" : "Tilføj din første opskrift!"}</p>
         </div>
       )}
 
@@ -111,7 +111,7 @@ export default function RecipeList() {
                 <h2 className="card-title">{recipe.title}</h2>
                 {recipe.ingredients?.length > 0 && (
                   <p className="card-ingredients">
-                    {recipe.ingredients.slice(0, 4).map(i => i.name).join(', ')}
+                    {recipe.ingredients.slice(0, 4).map(i => i.name).join(", ")}
                     {recipe.ingredients.length > 4 && ` +${recipe.ingredients.length - 4} mere`}
                   </p>
                 )}
@@ -133,7 +133,8 @@ export default function RecipeList() {
             </div>
           ))}
         </div>
-      )}
+      );
+    }
     </main>
   )
 }


### PR DESCRIPTION
## Linked issues

Closes #79
Closes #46
Closes #44
Closes #48
Closes #49

---

## What was done?

- Migrated the backend off Express to the Node.js `http` standard library: custom router (`backend/http/router.js`), response helpers (`backend/http/responses.js`), and Swagger serving (`backend/http/swagger.js`); Express dropped from `package.json` (PR #82).
- Split the three-VM deploy in CI into separate `database` / `backend` / `nginx` jobs with consistent "to Azure VM" naming.
- Added a post-deploy smoke test in CI (frontend returns `200` + API serves recipes).
- **Added ESLint + Prettier linting (PR #85):** flat-config ESLint for both `backend/eslint.config.js` and `frontend/eslint.config.js`, `lint` / `lint:fix` scripts in both `package.json`s, CI lint steps for backend and frontend, and a `RUN npm run lint` step in `frontend/Dockerfile` so a lint failure fails the build. Existing source was reformatted to satisfy the rules and README documents how to run it.
- Bundled the Definition of Done docs merged into `dev` via PR #83 (`definition-of-done.md`, plus `AGENTS.md` §8 and `CLAUDE.md`).
- Re-converged `dev` with `master` (back-merge of the release-merge commits from PRs #77/#78) so this PR is the only outstanding divergence.

---

## Why was this change needed?

- The course forbids Express; the backend must run on the Node standard library.
- The monolithic deploy job didn't reflect the three-VM (database/backend/nginx) blue-green topology already running in prod — splitting it makes per-tier failures legible.
- A post-deploy smoke test catches a broken deploy before it is declared green.
- Linting enforces a consistent style and catches errors early — wired into both CI and the frontend Docker build so it can't be skipped.

---

## How was it tested?

- Brought the stack up locally with `docker compose --profile dev up -d --build`. Verified: frontend `/` → `200`, API `/api/recipe/recipes/` → `200` with seeded data, `/api` info endpoint → `200`, Swagger `/apidocs` → `200`. Backend logs "Node API running" (no Express).
- Verified linting locally inside Docker: `npm run lint` passes for backend and frontend, and the frontend image builds clean with the in-build lint step.
- Ran `bash scripts/security-check.sh` — passed (no forbidden files, no secrets, `npm audit` clean on backend + frontend).

---

## ⚠️ Sensitive paths (AGENTS.md §4)

This PR modifies:
- **`.github/workflows/ci-cd.yml`** — three-VM deploy job split, post-deploy smoke test, and backend + frontend lint steps.
- **`frontend/Dockerfile`** — added `RUN npm run lint` before the build stage.

No `infrastructure/` changes. Merging to `master` auto-deploys to the Azure VM.

---

## Checklist

- [x] Code works locally (Docker compose `dev` profile comes up clean)
- [x] Linting passes locally and in CI (backend + frontend)
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
