### PR TITLE
Release: frontend English translation + test setup fix + postcss patch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="da">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4652,9 +4652,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4980,9 +4980,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5000,7 +5000,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,20 +17,20 @@ function RecipeLayout({ children }) {
             ✦ Cookbook
           </Link>
           <nav>
-            <Link to="/recipes" className="nav-link">Opskrifter</Link>
+            <Link to="/recipes" className="nav-link">Recipes</Link>
             {user ? (
               <div className="nav-actions">
                 <span className="nav-user">{user.name || user.email}</span>
                 <button className="btn-secondary" onClick={logout}>
-                  Log ud
+                  Log out
                 </button>
                 <button className="btn-primary" onClick={() => navigate("/recipes/new")}>
-                  + Ny opskrift
+                  + New recipe
                 </button>
               </div>
             ) : (
               <button className="btn-primary" onClick={() => navigate("/login")}>
-                Log ind
+                Log in
               </button>
             )}
           </nav>
@@ -49,7 +49,7 @@ function RequireAuth({ children }) {
     return (
       <RecipeLayout>
         <main className="main">
-          <div className="loading"><div className="spinner" /> Henter bruger...</div>
+          <div className="loading"><div className="spinner" /> Loading user...</div>
         </main>
       </RecipeLayout>
     );

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -2,23 +2,23 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import App from "../App";
 
-// Canvas kræver WebGL — erstat med en simpel wrapper i jsdom
+// Canvas requires WebGL — replace it with a simple wrapper in jsdom
 vi.mock("@react-three/fiber", () => ({
   Canvas: ({ children }) => <div data-testid="canvas-mock">{children}</div>,
   useFrame: vi.fn(),
 }));
 
-// Globe bruger useFrame/useTexture internt — mock hele komponenten
+// Globe uses useFrame/useTexture internally — mock the whole component
 vi.mock("../components/Globe", () => ({
   default: () => null,
   COUNTRIES: [
-    { id: "italy",    name: "Italien",  flag: "🇮🇹", lat: 42.5, lng: 12.5,   color: "#FF4D4D" },
-    { id: "france",   name: "Frankrig", flag: "🇫🇷", lat: 46.6, lng: 2.2,    color: "#5B9BD5" },
-    { id: "denmark",  name: "Danmark",  flag: "🇩🇰", lat: 55.7, lng: 9.5,    color: "#FF6B6B" },
+    { id: "italy",    name: "Italy",    flag: "🇮🇹", lat: 42.5, lng: 12.5,   color: "#FF4D4D" },
+    { id: "france",   name: "France",   flag: "🇫🇷", lat: 46.6, lng: 2.2,    color: "#5B9BD5" },
+    { id: "denmark",  name: "Denmark",  flag: "🇩🇰", lat: 55.7, lng: 9.5,    color: "#FF6B6B" },
     { id: "japan",    name: "Japan",    flag: "🇯🇵", lat: 36.2, lng: 138.2,  color: "#FF4D6A" },
-    { id: "india",    name: "Indien",   flag: "🇮🇳", lat: 20.6, lng: 79.0,   color: "#FFB347" },
+    { id: "india",    name: "India",    flag: "🇮🇳", lat: 20.6, lng: 79.0,   color: "#FFB347" },
     { id: "thailand", name: "Thailand", flag: "🇹🇭", lat: 15.9, lng: 100.9,  color: "#47A0FF" },
-    { id: "morocco",  name: "Marokko",  flag: "🇲🇦", lat: 31.8, lng: -7.1,   color: "#E85D5D" },
+    { id: "morocco",  name: "Morocco",  flag: "🇲🇦", lat: 31.8, lng: -7.1,   color: "#E85D5D" },
     { id: "mexico",   name: "Mexico",   flag: "🇲🇽", lat: 23.6, lng: -102.5, color: "#4DCB8A" },
   ],
 }));
@@ -28,19 +28,19 @@ vi.mock("../components/CountryPanel", () => ({
 }));
 
 describe("App", () => {
-  it("renderer uden at kaste fejl (smoke test)", () => {
-    // Kaster en exception → testen fejler. Det er hele pointen med en smoke test.
+  it("renders without throwing (smoke test)", () => {
+    // Throwing an exception → the test fails. That's the whole point of a smoke test.
     render(<App />);
   });
 
-  it("viser Cookbook-logoet på landingssiden", () => {
+  it("shows the Cookbook logo on the landing page", () => {
     render(<App />);
-    // LandingPage renderer <span className="landing-logo-title">Cookbook</span>
+    // LandingPage renders <span className="landing-logo-title">Cookbook</span>
     expect(screen.getByText("Cookbook")).toBeInTheDocument();
   });
 
-  it("viser subline \"Verdenskøkkenet\" på landingssiden", () => {
+  it("shows the \"World Cuisine\" subline on the landing page", () => {
     render(<App />);
-    expect(screen.getByText("Verdenskøkkenet")).toBeInTheDocument();
+    expect(screen.getByText("World Cuisine")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/RecipeList.test.jsx
+++ b/frontend/src/__tests__/RecipeList.test.jsx
@@ -3,12 +3,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import RecipeList from "../pages/RecipeList";
 
-// Mock API-laget så testen aldrig rammer netværket
+// Mock the API layer so the test never hits the network
 vi.mock("../api/recipes", () => ({
   listRecipes: vi.fn(),
 }));
 
-// Hent mock-referencen EFTER vi.mock er sat op
+// Grab the mock reference AFTER vi.mock is set up
 import { listRecipes } from "../api/recipes";
 
 describe("RecipeList", () => {
@@ -16,8 +16,8 @@ describe("RecipeList", () => {
     vi.clearAllMocks();
   });
 
-  it("viser loading-state med det samme", () => {
-    // Returner et løfte der aldrig resolverer → spinner forbliver synlig
+  it("shows the loading state immediately", () => {
+    // Return a promise that never resolves → the spinner stays visible
     listRecipes.mockReturnValue(new Promise(() => {}));
 
     render(
@@ -26,16 +26,16 @@ describe("RecipeList", () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText(/Henter opskrifter/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading recipes/i)).toBeInTheDocument();
   });
 
-  it("viser opskrifter når API-kaldet lykkes", async () => {
+  it("shows recipes when the API call succeeds", async () => {
     listRecipes.mockResolvedValue([
       {
         id: 1,
         title: "Pasta Bolognese",
-        tags: [{ id: 1, name: "Italiensk" }],
-        ingredients: [{ name: "Spaghetti" }, { name: "Hakket oksekød" }],
+        tags: [{ id: 1, name: "Italian" }],
+        ingredients: [{ name: "Spaghetti" }, { name: "Ground beef" }],
         time_minutes: 30,
         price: null,
         image: null,
@@ -52,11 +52,11 @@ describe("RecipeList", () => {
       expect(screen.getByText("Pasta Bolognese")).toBeInTheDocument();
     });
 
-    // Tagget vises både i filter-bjælken og på kortet — brug getAllByText
-    expect(screen.getAllByText("Italiensk").length).toBeGreaterThan(0);
+    // The tag appears both in the filter bar and on the card — use getAllByText
+    expect(screen.getAllByText("Italian").length).toBeGreaterThan(0);
   });
 
-  it("viser fejlbesked når API-kaldet fejler", async () => {
+  it("shows an error message when the API call fails", async () => {
     listRecipes.mockRejectedValue(new Error("Network error"));
 
     render(
@@ -67,12 +67,12 @@ describe("RecipeList", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/Kunne ikke hente opskrifter/i)
+        screen.getByText(/Could not load recipes/i)
       ).toBeInTheDocument();
     });
   });
 
-  it("viser \"Ingen opskrifter endnu\" når listen er tom", async () => {
+  it("shows \"No recipes yet\" when the list is empty", async () => {
     listRecipes.mockResolvedValue([]);
 
     render(
@@ -82,7 +82,7 @@ describe("RecipeList", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Ingen opskrifter endnu/i)).toBeInTheDocument();
+      expect(screen.getByText(/No recipes yet/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/CountryPanel.jsx
+++ b/frontend/src/components/CountryPanel.jsx
@@ -15,7 +15,7 @@ export default function CountryPanel({ country, onClose }) {
     setRecipes([]);
     listRecipesByCountry(country.id)
       .then(data => { setRecipes(data); setLoading(false); })
-      .catch(() => { setError("Kunne ikke hente opskrifter."); setLoading(false); });
+      .catch(() => { setError("Could not load recipes."); setLoading(false); });
   }, [country]);
 
   // Close on backdrop click
@@ -29,7 +29,7 @@ export default function CountryPanel({ country, onClose }) {
       onClick={handleBackdropClick}
     >
       <aside className={`country-panel${isOpen ? " open" : ""}`}>
-        <button className="panel-close" onClick={onClose} aria-label="Luk">✕</button>
+        <button className="panel-close" onClick={onClose} aria-label="Close">✕</button>
 
         {country && (
           <>
@@ -37,7 +37,7 @@ export default function CountryPanel({ country, onClose }) {
               <span className="panel-flag">{country.flag}</span>
               <h2 className="panel-country-name">{country.name}</h2>
               <p className="panel-recipe-count">
-                {loading ? "…" : `${recipes.length} ${recipes.length === 1 ? "opskrift" : "opskrifter"}`}
+                {loading ? "…" : `${recipes.length} ${recipes.length === 1 ? "recipe" : "recipes"}`}
               </p>
               <div
                 className="panel-accent"
@@ -49,7 +49,7 @@ export default function CountryPanel({ country, onClose }) {
               {loading && (
                 <div className="panel-loading">
                   <div className="panel-spinner" />
-                  <span>Henter opskrifter…</span>
+                  <span>Loading recipes…</span>
                 </div>
               )}
 
@@ -63,7 +63,7 @@ export default function CountryPanel({ country, onClose }) {
               {!loading && !error && recipes.length === 0 && (
                 <div className="panel-empty">
                   <span className="panel-empty-icon">🍽</span>
-                  <span>Ingen opskrifter fra {country.name} endnu</span>
+                  <span>No recipes from {country.name} yet</span>
                 </div>
               )}
 

--- a/frontend/src/components/Globe.jsx
+++ b/frontend/src/components/Globe.jsx
@@ -6,13 +6,13 @@ import * as THREE from "three";
 const RADIUS = 2.2;
 
 export const COUNTRIES = [
-  { id: "italy",    name: "Italien",  flag: "🇮🇹", lat: 42.5,  lng: 12.5,   color: "#FF4D4D" },
-  { id: "france",   name: "Frankrig", flag: "🇫🇷", lat: 46.6,  lng: 2.2,    color: "#5B9BD5" },
-  { id: "denmark",  name: "Danmark",  flag: "🇩🇰", lat: 55.7,  lng: 9.5,    color: "#FF6B6B" },
+  { id: "italy",    name: "Italy",    flag: "🇮🇹", lat: 42.5,  lng: 12.5,   color: "#FF4D4D" },
+  { id: "france",   name: "France",   flag: "🇫🇷", lat: 46.6,  lng: 2.2,    color: "#5B9BD5" },
+  { id: "denmark",  name: "Denmark",  flag: "🇩🇰", lat: 55.7,  lng: 9.5,    color: "#FF6B6B" },
   { id: "japan",    name: "Japan",    flag: "🇯🇵", lat: 36.2,  lng: 138.2,  color: "#FF4D6A" },
   { id: "mexico",   name: "Mexico",   flag: "🇲🇽", lat: 23.6,  lng: -102.5, color: "#4DCB8A" },
-  { id: "india",    name: "Indien",   flag: "🇮🇳", lat: 20.6,  lng: 79.0,   color: "#FFB347" },
-  { id: "morocco",  name: "Marokko",  flag: "🇲🇦", lat: 31.8,  lng: -7.1,   color: "#E85D5D" },
+  { id: "india",    name: "India",    flag: "🇮🇳", lat: 20.6,  lng: 79.0,   color: "#FFB347" },
+  { id: "morocco",  name: "Morocco",  flag: "🇲🇦", lat: 31.8,  lng: -7.1,   color: "#E85D5D" },
   { id: "thailand", name: "Thailand", flag: "🇹🇭", lat: 15.9,  lng: 100.9,  color: "#47A0FF" },
 ];
 

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -34,7 +34,7 @@ export default function LandingPage() {
       {/* Intro animation */}
       {showIntro && (
         <div className="intro-overlay">
-          <p className="intro-text">Hvilket land skal vi spise i dag?</p>
+          <p className="intro-text">Which country shall we eat in today?</p>
         </div>
       )}
 
@@ -42,23 +42,23 @@ export default function LandingPage() {
       <header className="landing-header">
         <div className="landing-logo">
           <span className="landing-logo-title">Cookbook</span>
-          <span className="landing-logo-sub">Verdenskøkkenet</span>
+          <span className="landing-logo-sub">World Cuisine</span>
         </div>
         <nav className="landing-nav">
-          <Link to="/recipes" className="landing-nav-link">Alle opskrifter</Link>
+          <Link to="/recipes" className="landing-nav-link">All recipes</Link>
           {user ? (
             <button className="landing-nav-link landing-nav-button" onClick={logout}>
-              Log ud
+              Log out
             </button>
           ) : (
-            <Link to="/login" className="landing-nav-link">Log ind</Link>
+            <Link to="/login" className="landing-nav-link">Log in</Link>
           )}
         </nav>
       </header>
 
       {/* Hint */}
       {!showIntro && (
-        <p className="globe-hint">Klik på et pin for at se opskrifter</p>
+        <p className="globe-hint">Click a pin to see recipes</p>
       )}
 
       {/* 3D Globe */}
@@ -76,10 +76,10 @@ export default function LandingPage() {
       {/* Bottom-left country buttons grouped by continent */}
       <div className="country-bar">
         {[
-          { continent: "Europa", ids: ["italy", "france", "denmark"] },
-          { continent: "Asien",  ids: ["japan", "india", "thailand"] },
-          { continent: "Afrika", ids: ["morocco"] },
-          { continent: "Amerika", ids: ["mexico"] },
+          { continent: "Europe",   ids: ["italy", "france", "denmark"] },
+          { continent: "Asia",     ids: ["japan", "india", "thailand"] },
+          { continent: "Africa",   ids: ["morocco"] },
+          { continent: "Americas", ids: ["mexico"] },
         ].map(group => (
           <div key={group.continent} className="continent-group">
             <span className="continent-label">{group.continent}</span>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -56,21 +56,21 @@ export default function LoginPage() {
             className={`auth-tab${!isRegister ? " active" : ""}`}
             onClick={() => { setMode("login"); setError(""); }}
           >
-            Log ind
+            Log in
           </button>
           <button
             type="button"
             className={`auth-tab${isRegister ? " active" : ""}`}
             onClick={() => { setMode("register"); setError(""); }}
           >
-            Opret bruger
+            Create account
           </button>
         </div>
 
         <form onSubmit={submit} className="auth-form">
           {isRegister && (
             <div className="form-group">
-              <label htmlFor="name">Navn</label>
+              <label htmlFor="name">Name</label>
               <input
                 id="name"
                 type="text"
@@ -109,7 +109,7 @@ export default function LoginPage() {
           {error && <div className="error-msg">{error}</div>}
 
           <button className="btn-primary auth-submit" type="submit" disabled={saving}>
-            {saving ? "Gemmer..." : isRegister ? "Opret bruger" : "Log ind"}
+            {saving ? "Saving..." : isRegister ? "Create account" : "Log in"}
           </button>
         </form>
       </section>

--- a/frontend/src/pages/RecipeDetail.jsx
+++ b/frontend/src/pages/RecipeDetail.jsx
@@ -15,28 +15,28 @@ export default function RecipeDetail() {
     setLoading(true);
     getRecipe(id)
       .then(data => { setRecipe(data); setLoading(false); })
-      .catch(() => { setError("Kunne ikke hente opskrift."); setLoading(false); });
+      .catch(() => { setError("Could not load recipe."); setLoading(false); });
   }, [id]);
 
   const handleDelete = async () => {
-    if (!confirm(`Slet "${recipe.title}"?`)) return;
+    if (!confirm(`Delete "${recipe.title}"?`)) return;
     try {
       await deleteRecipe(id);
       navigate("/recipes");
     } catch {
-      setError("Kunne ikke slette opskriften. Prøv igen.");
+      setError("Could not delete the recipe. Please try again.");
     }
   };
 
   if (loading) return (
     <main className="main">
-      <div className="loading"><div className="spinner" /> Henter…</div>
+      <div className="loading"><div className="spinner" /> Loading…</div>
     </main>
   );
 
   if (error) return (
     <main className="main">
-      <button className="back-btn" onClick={() => navigate("/recipes")}>← Tilbage</button>
+      <button className="back-btn" onClick={() => navigate("/recipes")}>← Back</button>
       <div className="error-msg">{error}</div>
     </main>
   );
@@ -45,7 +45,7 @@ export default function RecipeDetail() {
 
   return (
     <main className="main">
-      <button className="back-btn" onClick={() => navigate("/recipes")}>← Alle opskrifter</button>
+      <button className="back-btn" onClick={() => navigate("/recipes")}>← All recipes</button>
 
       {recipe.image && (
         <div className="detail-image">
@@ -56,7 +56,7 @@ export default function RecipeDetail() {
       <h1 className="detail-title">{recipe.title}</h1>
 
       <div className="detail-meta">
-        {recipe.time_minutes && <span>⏱ {recipe.time_minutes} minutter</span>}
+        {recipe.time_minutes && <span>⏱ {recipe.time_minutes} minutes</span>}
         {recipe.price && <span>💰 {recipe.price} kr</span>}
       </div>
 
@@ -77,16 +77,16 @@ export default function RecipeDetail() {
               className="btn-primary"
               onClick={() => navigate(`/recipes/${id}/edit`, { state: { recipe } })}
             >
-              Rediger
+              Edit
             </button>
             <button className="btn-danger" onClick={handleDelete}>
-              Slet
+              Delete
             </button>
           </>
         )}
         {recipe.link && (
           <a href={recipe.link} target="_blank" rel="noopener noreferrer" className="recipe-link">
-            ↗ Originalkilde
+            ↗ Original source
           </a>
         )}
       </div>
@@ -94,7 +94,7 @@ export default function RecipeDetail() {
       <div className="detail-body">
         {recipe.ingredients?.length > 0 && (
           <aside className="ingredients-card">
-            <h2 className="section-title">Ingredienser</h2>
+            <h2 className="section-title">Ingredients</h2>
             <ul className="ingredient-list">
               {recipe.ingredients.map(ing => (
                 <li key={ing.id} className="ingredient-item">
@@ -108,7 +108,7 @@ export default function RecipeDetail() {
 
         {steps.length > 0 && (
           <section>
-            <h2 className="section-title">Fremgangsmåde</h2>
+            <h2 className="section-title">Instructions</h2>
             {steps.map((step, i) => (
               <div key={i} className="instruction-step">
                 <div className="step-number">{i + 1}</div>

--- a/frontend/src/pages/RecipeForm.jsx
+++ b/frontend/src/pages/RecipeForm.jsx
@@ -43,7 +43,7 @@ export default function RecipeForm() {
       setLoading(true);
       getRecipe(id)
         .then(data => { setForm(toForm(data)); setLoading(false); })
-        .catch(() => { setError("Kunne ikke hente opskriften."); setLoading(false); });
+        .catch(() => { setError("Could not load the recipe."); setLoading(false); });
     }
   }, [id, isEdit, location.state]);
 
@@ -68,7 +68,7 @@ export default function RecipeForm() {
   const removeStep = (i) => set("instructions", form.instructions.filter((_, idx) => idx !== i));
 
   const handleSubmit = async () => {
-    if (!form.title.trim()) { setError("Opskriften skal have et navn."); return; }
+    if (!form.title.trim()) { setError("The recipe needs a name."); return; }
     setSaving(true); setError(null);
 
     const payload = {
@@ -91,7 +91,7 @@ export default function RecipeForm() {
         : await createRecipe(payload);
       navigate(`/recipes/${saved.id || id}`);
     } catch {
-      setError("Kunne ikke gemme opskriften. Prøv igen.");
+      setError("Could not save the recipe. Please try again.");
       setSaving(false);
     }
   };
@@ -104,92 +104,92 @@ export default function RecipeForm() {
   return (
     <main className="main">
       <button className="back-btn" onClick={handleCancel}>
-        ← {isEdit ? "Tilbage til opskrift" : "Tilbage"}
+        ← {isEdit ? "Back to recipe" : "Back"}
       </button>
 
       <div className="page-header">
-        <h1 className="page-title">{isEdit ? "Rediger opskrift" : "Ny opskrift"}</h1>
+        <h1 className="page-title">{isEdit ? "Edit recipe" : "New recipe"}</h1>
       </div>
 
       {error && <div className="error-msg" style={{ marginBottom: "1.5rem" }}>{error}</div>}
 
       {loading ? (
-        <div className="loading"><div className="spinner" /> Henter opskrift…</div>
+        <div className="loading"><div className="spinner" /> Loading recipe…</div>
       ) : (
         <div className="form-card">
 
           <div className="form-section">
-            <h2 className="form-section-title">Grundoplysninger</h2>
+            <h2 className="form-section-title">Basic details</h2>
             <div className="form-group">
-              <label>Navn *</label>
-              <input type="text" placeholder="f.eks. Spaghetti Carbonara"
+              <label>Name *</label>
+              <input type="text" placeholder="e.g. Spaghetti Carbonara"
                 value={form.title} onChange={e => set("title", e.target.value)} />
             </div>
             <div className="form-group">
-              <label>Beskrivelse</label>
-              <textarea placeholder="Kort beskrivelse…"
+              <label>Description</label>
+              <textarea placeholder="Short description…"
                 value={form.description} onChange={e => set("description", e.target.value)} />
             </div>
             <div className="form-row">
               <div className="form-group">
-                <label>Tid (minutter)</label>
+                <label>Time (minutes)</label>
                 <input type="number" placeholder="30"
                   value={form.time_minutes} onChange={e => set("time_minutes", e.target.value)} />
               </div>
               <div className="form-group">
-                <label>Pris (kr)</label>
+                <label>Price (kr)</label>
                 <input type="text" placeholder="45.00"
                   value={form.price} onChange={e => set("price", e.target.value)} />
               </div>
             </div>
             <div className="form-group">
-              <label>Link til kilde</label>
+              <label>Source link</label>
               <input type="text" placeholder="https://…"
                 value={form.link} onChange={e => set("link", e.target.value)} />
             </div>
             <div className="form-group">
-              <label>Billed-URL</label>
-              <input type="text" placeholder="https://… (link til et billede)"
+              <label>Image URL</label>
+              <input type="text" placeholder="https://… (link to an image)"
                 value={form.image} onChange={e => set("image", e.target.value)} />
               {form.image && (
-                <img src={form.image} alt="Forhåndsvisning" className="image-preview" />
+                <img src={form.image} alt="Preview" className="image-preview" />
               )}
             </div>
           </div>
 
           <div className="form-section">
-            <h2 className="form-section-title">Ingredienser</h2>
+            <h2 className="form-section-title">Ingredients</h2>
             <div className="dynamic-list">
               {form.ingredients.map((ing, i) => (
                 <div key={i} className="ingredient-row">
-                  <input type="text" placeholder="Navn" value={ing.name}
+                  <input type="text" placeholder="Name" value={ing.name}
                     onChange={e => updateIng(i, "name", e.target.value)} />
-                  <input type="text" placeholder="Mængde" value={ing.amount}
+                  <input type="text" placeholder="Amount" value={ing.amount}
                     onChange={e => updateIng(i, "amount", e.target.value)} />
-                  <input type="text" placeholder="Enhed" value={ing.unit}
+                  <input type="text" placeholder="Unit" value={ing.unit}
                     onChange={e => updateIng(i, "unit", e.target.value)} />
                   <button className="btn-remove" onClick={() => removeIng(i)}
                     disabled={form.ingredients.length === 1}>×</button>
                 </div>
               ))}
             </div>
-            <button className="btn-add" onClick={addIng}>+ Tilføj ingrediens</button>
+            <button className="btn-add" onClick={addIng}>+ Add ingredient</button>
           </div>
 
           <div className="form-section">
-            <h2 className="form-section-title">Fremgangsmåde</h2>
+            <h2 className="form-section-title">Instructions</h2>
             <div className="dynamic-list">
               {form.instructions.map((step, i) => (
                 <div key={i} className="dynamic-item">
                   <span style={{ color: "var(--text-muted)", fontSize: "0.8rem", minWidth: 20 }}>{i + 1}.</span>
-                  <textarea placeholder={`Trin ${i + 1}…`} value={step}
+                  <textarea placeholder={`Step ${i + 1}…`} value={step}
                     onChange={e => updateStep(i, e.target.value)} style={{ minHeight: 60 }} />
                   <button className="btn-remove" onClick={() => removeStep(i)}
                     disabled={form.instructions.length === 1}>×</button>
                 </div>
               ))}
             </div>
-            <button className="btn-add" onClick={addStep}>+ Tilføj trin</button>
+            <button className="btn-add" onClick={addStep}>+ Add step</button>
           </div>
 
           <div className="form-section">
@@ -197,20 +197,20 @@ export default function RecipeForm() {
             <div className="dynamic-list">
               {form.tags.map((tag, i) => (
                 <div key={i} className="dynamic-item">
-                  <input type="text" placeholder="f.eks. italiensk" value={tag.name}
+                  <input type="text" placeholder="e.g. italian" value={tag.name}
                     onChange={e => updateTag(i, e.target.value)} />
                   <button className="btn-remove" onClick={() => removeTag(i)}
                     disabled={form.tags.length === 1}>×</button>
                 </div>
               ))}
             </div>
-            <button className="btn-add" onClick={addTag}>+ Tilføj tag</button>
+            <button className="btn-add" onClick={addTag}>+ Add tag</button>
           </div>
 
           <div className="form-actions">
-            <button className="btn-secondary" onClick={handleCancel}>Annullér</button>
+            <button className="btn-secondary" onClick={handleCancel}>Cancel</button>
             <button className="btn-primary" onClick={handleSubmit} disabled={saving}>
-              {saving ? "Gemmer…" : isEdit ? "Gem ændringer" : "Opret opskrift"}
+              {saving ? "Saving…" : isEdit ? "Save changes" : "Create recipe"}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/RecipeList.jsx
+++ b/frontend/src/pages/RecipeList.jsx
@@ -13,7 +13,7 @@ export default function RecipeList() {
   useEffect(() => {
     listRecipes()
       .then(data => { setRecipes(data); setLoading(false); })
-      .catch(() => { setError("Kunne ikke hente opskrifter."); setLoading(false); });
+      .catch(() => { setError("Could not load recipes."); setLoading(false); });
   }, []);
 
   const allTags = useMemo(() => {
@@ -33,14 +33,14 @@ export default function RecipeList() {
   return (
     <main className="main">
       <button className="back-btn" onClick={() => navigate("/")}>
-        ← Verdenskøkkenet
+        ← World Cuisine
       </button>
 
       <div className="section-header">
-        <h1 className="section-title-lg">Alle opskrifter</h1>
+        <h1 className="section-title-lg">All recipes</h1>
         {!loading && (
           <span className="section-count">
-            {filtered.length} {filtered.length === 1 ? "opskrift" : "opskrifter"}
+            {filtered.length} {filtered.length === 1 ? "recipe" : "recipes"}
           </span>
         )}
       </div>
@@ -49,7 +49,7 @@ export default function RecipeList() {
         <div className="search-wrap">
           <input
             type="text"
-            placeholder="Søg i opskrifter eller tags…"
+            placeholder="Search recipes or tags…"
             value={search}
             onChange={e => setSearch(e.target.value)}
           />
@@ -60,7 +60,7 @@ export default function RecipeList() {
               className={`tag-filter-btn${!activeTag ? " active" : ""}`}
               onClick={() => setActiveTag(null)}
             >
-              Alle
+              All
             </button>
             {allTags.map(tag => (
               <button
@@ -75,14 +75,14 @@ export default function RecipeList() {
         )}
       </div>
 
-      {loading && <div className="loading"><div className="spinner" /> Henter opskrifter…</div>}
+      {loading && <div className="loading"><div className="spinner" /> Loading recipes…</div>}
       {error && <div className="error-msg">{error}</div>}
 
       {!loading && !error && filtered.length === 0 && (
         <div className="empty">
           <div className="empty-icon">🍽</div>
-          <h3>{search || activeTag ? "Ingen resultater" : "Ingen opskrifter endnu"}</h3>
-          <p>{search || activeTag ? "Prøv et andet søgeord eller filter" : "Tilføj din første opskrift!"}</p>
+          <h3>{search || activeTag ? "No results" : "No recipes yet"}</h3>
+          <p>{search || activeTag ? "Try a different search term or filter" : "Add your first recipe!"}</p>
         </div>
       )}
 
@@ -112,7 +112,7 @@ export default function RecipeList() {
                 {recipe.ingredients?.length > 0 && (
                   <p className="card-ingredients">
                     {recipe.ingredients.slice(0, 4).map(i => i.name).join(", ")}
-                    {recipe.ingredients.length > 4 && ` +${recipe.ingredients.length - 4} mere`}
+                    {recipe.ingredients.length > 4 && ` +${recipe.ingredients.length - 4} more`}
                   </p>
                 )}
                 <div className="card-footer">

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,16 @@
 import "@testing-library/jest-dom";
+import { beforeEach, vi } from "vitest";
+
+// jsdom (v29) does not expose a usable window.localStorage by default, and
+// auth.js reads it on mount via getAuthToken(). Provide a small in-memory
+// implementation so component tests render deterministically.
+const store = new Map();
+
+vi.stubGlobal("localStorage", {
+  getItem: (key) => (store.has(key) ? store.get(key) : null),
+  setItem: (key, value) => store.set(key, String(value)),
+  removeItem: (key) => store.delete(key),
+  clear: () => store.clear(),
+});
+
+beforeEach(() => store.clear());


### PR DESCRIPTION
# Pull Request

## Linked issues

Closes #71, Closes #54

---

## What was done?

- Translate all remaining frontend UI strings from Danish to English — landing page, login, recipe list / detail / form, country panel, and globe (completes the translation deliverable of #71; `git grep` for Danish characters in `frontend/` source is now empty).
- Harden the jsdom test setup with a deterministic in-memory `localStorage` so component tests render reliably — `auth.js` reads it on mount and jsdom does not expose a usable implementation by default (#54).
- Bump transitive `postcss` to patch an XSS advisory flagged by `npm audit` (security hotfix, bundled).

Note: #71 also mentions reorganising `frontend/src/` into `features/` folders. That restructure was **not** done in this PR — files remain under `pages/`/`components/`. The issue's explicit "Done when" criteria (translation complete, UI works, build green) are all met.

---

## Why was this change needed?

- Project language policy: the whole project standardizes on English (only `definition-of-done.md` stays Danish).
- Frontend component tests were non-deterministic because jsdom lacks a usable `localStorage` that `auth.js` depends on at mount.
- The `postcss` advisory needs patching to keep `npm audit --audit-level=high` clean.

---

## How was it tested?

- `git grep -P "[æøåÆØÅ]" -- frontend/` returns no source matches (only a binary texture filename).
- Frontend test suite (`App` + `RecipeList`) renders and passes with the new in-memory `localStorage`.
- `bash scripts/security-check.sh` passes: forbidden-file check, secret scan, and `npm audit --audit-level=high` clean in both `backend/` and `frontend/`.

---

## Checklist

- [ ] Code works locally (Docker compose `dev` profile comes up clean) — not re-run for this PR; changes are integration-tested on `dev` and CI covers build/test.
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that's called out above — it does not; frontend-only changes.
