### PR TITLE
Update landing page intro text

### DIFF
--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -22,7 +22,7 @@ export default function LandingPage() {
 
   // Hide intro text after animation completes (3 s)
   useEffect(() => {
-    const t = setTimeout(() => setShowIntro(false), 3100);
+    const t = setTimeout(() => setShowIntro(false), 6000);
     return () => clearTimeout(t);
   }, []);
 
@@ -34,7 +34,7 @@ export default function LandingPage() {
       {/* Intro animation */}
       {showIntro && (
         <div className="intro-overlay">
-          <p className="intro-text">Which country shall we eat in today?</p>
+          <p className="intro-text">Where will dinner take you today?</p>
         </div>
       )}
 


### PR DESCRIPTION
## Linked issues
No tracked issue matched this intro copy change.

---

## What was done?
Briefly describe what you changed or added.

- Updated the landing page intro copy from "Which country shall we eat in today?" to "Where will dinner take you today?"
- Extended the intro overlay timeout from 3.1 seconds to 6 seconds

---

## Why was this change needed?
Short explanation of the purpose.

The new intro text is broader and less awkward, and the longer timeout gives users more time to read it before the landing page appears.

---

## How was it tested?
Describe how you checked that it works.

- Reviewed the diff for `frontend/src/pages/LandingPage.jsx`
- Ran `bash scripts/security-check.sh` and it passed
- Docker compose was not run for this text-only PR

---

## Checklist

- [ ] Code works locally (Docker compose `dev` profile comes up clean)
- [x] Ran `bash scripts/security-check.sh` and it passed
- [x] No obvious errors
- [x] Teammates can understand the change
- [x] If this PR touches `.github/workflows/`, `infrastructure/`, or any `Dockerfile`, that is called out above