### PR TITLE
fix(ci): harden Grafana smoke test (hotfix for #127 master failure)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -446,7 +446,7 @@ jobs:
           echo "Smoke test passed: frontend 200 + API serving recipes"
 
   deploy-three-vms-monitoring:
-    name: Deploy monitoring to Azure VM
+    name: Deploy monitoring stack to nginx VM
     runs-on: ubuntu-latest
     needs: [deploy-three-vms-nginx]
     if: |
@@ -517,8 +517,20 @@ jobs:
         run: |
           BASE="http://$NGINX_HOST"
           echo "Smoke testing $BASE/grafana/login ..."
-          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 --retry 10 --retry-delay 3 --retry-all-errors "$BASE/grafana/login")
-          echo "Grafana login returned HTTP $code"
+
+          # Retry in-shell instead of relying on curl --retry-all-errors,
+          # which has flaky interactions with -w and can exit 23 mid-run.
+          code="000"
+          for attempt in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$BASE/grafana/login" || echo "000")
+            echo "Attempt $attempt: HTTP $code"
+            case "$code" in
+              200|302) break;;
+            esac
+            sleep 3
+          done
+
+          echo "Grafana login final HTTP $code"
           # Grafana redirects unauthenticated users; 200 (login page) or 302 (redirect to login) both mean it's up.
           case "$code" in
             200|302) echo "Grafana smoke test passed";;


### PR DESCRIPTION
## Summary

- Master CI failed after #127 merged because the Grafana smoke test step exited with curl code 23 (CURLE_WRITE_ERROR) — `curl --retry-all-errors` combined with `-w` is flaky and gave zero diagnostic signal before `set -e` killed the script.
- Replaced it with an in-shell retry loop that captures curl's exit code via `|| echo "000"`, logs every attempt's HTTP code, and breaks early on 200/302. We now always reach the final case-statement.
- Renamed the `deploy-three-vms-monitoring` job from "Deploy monitoring to Azure VM" to "Deploy monitoring stack to nginx VM" so the GitHub Actions UI stops implying a 4th VM exists — the job has always SSHed into the existing nginx VM and run `docker compose` there.

Verified via `workflow_dispatch` on dev ([run 26479755791](https://github.com/Balladebaderne/cookbook/actions/runs/26479755791)): smoke test passed on Attempt 1 (HTTP 200), all 7 jobs green.

## Test plan

- [x] Workflow dispatched on dev — full deploy pipeline green incl. the renamed monitoring job
- [x] Smoke test logged "Attempt 1: HTTP 200" → "Grafana smoke test passed"
- [ ] After merge, master CI/CD Pipeline run goes fully green
- [ ] `http://<nginx>/grafana/login` still serves Grafana login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)