### PR TITLE
Release dev → master: Phase 1 alerting (#132) + pin Azure subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ credentials/
 *.key
 *.pub
 
+# Alertmanager Discord webhook URL (the .example template is tracked).
+# Also covered by the secrets/ rule above; listed explicitly for clarity.
+monitoring/alertmanager/secrets/discord_url
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,10 @@ credentials/
 *.key
 *.pub
 
-# Alertmanager Discord webhook URL (the .example template is tracked).
+# Alertmanager Discord webhook URL + github-receiver auth token.
 # Also covered by the secrets/ rule above; listed explicitly for clarity.
 monitoring/alertmanager/secrets/discord_url
+monitoring/github-receiver/secrets/gh_token
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -79,15 +79,17 @@ The application is deployed and running at the static public IP below.
 
 | Status | Endpoint | URL |
 |---|---|---|
-| 200 | Web UI (React SPA) | `http://20.216.171.163/` |
-| 200 | Swagger UI | `http://20.216.171.163/apidocs` |
-| 200 | Grafana | `http://20.216.171.163/grafana/` |
+| 200 | Web UI (React SPA) | `http://4.211.254.152/` |
+| 200 | Swagger UI | `http://4.211.254.152/apidocs` |
+| 200 | Grafana | `http://4.211.254.152/grafana/` |
 
-> The public IP (`20.216.171.163`) is a static Azure resource in the
-> `rg-balladebaderne` resource group and is preserved across teardown and
-> re-provision — as long as the same Azure account is used. Migrating the
-> infrastructure to a different account changes the IP, and this section should
-> be updated.
+> The public IP (`4.211.254.152`) is a static Azure resource in the
+> `rg-balladebaderne` resource group of the **shared team subscription**, and is
+> preserved across teardown and re-provision: `azure-teardown.sh` keeps the IP,
+> and both infra scripts pin that subscription so a stale `az` default can't
+> redirect the deploy elsewhere. The IP only changes if the shared subscription
+> itself changes — in which case update `SUBSCRIPTION_ID` in the infra scripts
+> and this section.
 
 > **Note:** HTTPS (port 443) is not configured yet — all traffic runs over HTTP.
 
@@ -233,7 +235,7 @@ Add the badge once the project exists:
 
 Prometheus + Grafana run as a separate stack on the shared `cookbook-network`
 and are **deployed to prod** alongside the app — Grafana is live at
-<http://20.216.171.163/grafana/>. Prometheus stays internal.
+<http://4.211.254.152/grafana/>. Prometheus stays internal.
 
 The provisioned **"Cookbook — Application Overview"** dashboard tracks request
 rate, p95 latency, 5xx error rate, and container up/down (from the backend's

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -50,7 +50,7 @@ Cookbook-projektet er *Done*, når alle relevante krav er opfyldt.
 - [ ] Netværk og firewall er korrekt konfigureret.
 - [x] Monitoring er aktivt: logs, metrics og alerts. _(Prometheus/Grafana-stakken deployes til nginx-VM'en som en del af nginx-deploy-jobbet i CI/CD; Grafana er nået via `/grafana`, backend scrapes via privat IP for blue+green. Beslutning om dedikeret monitoring-VM (#108, 12.6) afventer gruppe.)_
 - [x] Health endpoint `/health` fungerer.
-- [x] Systemet er live og tilgængeligt.
+- [x] Systemet er live og tilgængeligt. _(Fast offentlig IP `4.211.254.152` (Standard, statisk) i den delte team-subscription; `create_three_vms.sh` og `azure-teardown.sh` pinner subscriptionen, så IP'en overlever teardown/re-provision og ikke kan ende i en personlig subscription.)_
 
 ---
 

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -48,7 +48,7 @@ Cookbook-projektet er *Done*, når alle relevante krav er opfyldt.
 ## 6. Infrastruktur & Drift
 - [x] Systemet kører på Azure VMs.
 - [ ] Netværk og firewall er korrekt konfigureret.
-- [x] Monitoring er aktivt: logs, metrics og alerts. _(Prometheus/Grafana-stakken deployes til nginx-VM'en som en del af nginx-deploy-jobbet i CI/CD; Grafana er nået via `/grafana`, backend scrapes via privat IP for blue+green. Beslutning om dedikeret monitoring-VM (#108, 12.6) afventer gruppe. **Alerting (#132):** Prometheus alert-regler → Alertmanager → Discord-besked + auto-oprettet GitHub-issue; Phase 1 (regler + Alertmanager + github-receiver) bygget og config-valideret lokalt, Phase 2 (CI-wiring + `DISCORD_WEBHOOK_URL`/`GH_ISSUE_TOKEN`-secrets) afventer gruppe-sign-off.)_
+- [x] Monitoring er aktivt: logs, metrics og alerts. _(Prometheus/Grafana-stakken deployes til nginx-VM'en som en del af nginx-deploy-jobbet i CI/CD; Grafana er nået via `/grafana`, backend scrapes via privat IP for blue+green. Beslutning om dedikeret monitoring-VM (#108, 12.6) afventer gruppe. **Alerting (#132):** Prometheus alert-regler → Alertmanager → Discord-besked + auto-oprettet GitHub-issue; Phase 1 (regler + Alertmanager + github-receiver) bygget og **end-to-end-testet lokalt** (Discord-levering + GitHub-issue-oprettelse + auto-close ved resolve alle verificeret), Phase 2 (CI-wiring + `DISCORD_WEBHOOK_URL`/`GH_ISSUE_TOKEN`-secrets) afventer gruppe-sign-off.)_
 - [x] Health endpoint `/health` fungerer.
 - [x] Systemet er live og tilgængeligt. _(Fast offentlig IP `4.211.254.152` (Standard, statisk) i den delte team-subscription; `create_three_vms.sh` og `azure-teardown.sh` pinner subscriptionen, så IP'en overlever teardown/re-provision og ikke kan ende i en personlig subscription.)_
 

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -48,7 +48,7 @@ Cookbook-projektet er *Done*, når alle relevante krav er opfyldt.
 ## 6. Infrastruktur & Drift
 - [x] Systemet kører på Azure VMs.
 - [ ] Netværk og firewall er korrekt konfigureret.
-- [x] Monitoring er aktivt: logs, metrics og alerts. _(Prometheus/Grafana-stakken deployes til nginx-VM'en som en del af nginx-deploy-jobbet i CI/CD; Grafana er nået via `/grafana`, backend scrapes via privat IP for blue+green. Beslutning om dedikeret monitoring-VM (#108, 12.6) afventer gruppe.)_
+- [x] Monitoring er aktivt: logs, metrics og alerts. _(Prometheus/Grafana-stakken deployes til nginx-VM'en som en del af nginx-deploy-jobbet i CI/CD; Grafana er nået via `/grafana`, backend scrapes via privat IP for blue+green. Beslutning om dedikeret monitoring-VM (#108, 12.6) afventer gruppe. **Alerting (#132):** Prometheus alert-regler → Alertmanager → Discord-besked + auto-oprettet GitHub-issue; Phase 1 (regler + Alertmanager + github-receiver) bygget og config-valideret lokalt, Phase 2 (CI-wiring + `DISCORD_WEBHOOK_URL`/`GH_ISSUE_TOKEN`-secrets) afventer gruppe-sign-off.)_
 - [x] Health endpoint `/health` fungerer.
 - [x] Systemet er live og tilgængeligt. _(Fast offentlig IP `4.211.254.152` (Standard, statisk) i den delte team-subscription; `create_three_vms.sh` og `azure-teardown.sh` pinner subscriptionen, så IP'en overlever teardown/re-provision og ikke kan ende i en personlig subscription.)_
 

--- a/infrastructure/azure-teardown.sh
+++ b/infrastructure/azure-teardown.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 # link survives a teardown + re-provision cycle (create_three_vms.sh reuses it).
 # Destructive and irreversible — requires explicit confirmation.
 
+# Pin to the SHARED team subscription (same as create_three_vms.sh) so a teardown
+# can never delete resources in the wrong subscription. Override: SUBSCRIPTION_ID=...
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-f0b6692d-2ce5-450d-a954-741c7cad136c}"
+
 RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
 GITHUB_REPO="${GITHUB_REPO:-Balladebaderne/cookbook}"
 PUBLIC_IP_NAME="${PUBLIC_IP_NAME:-cookbook-nginx-ip}"
@@ -17,8 +21,15 @@ die() { printf '\n\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 
 command -v az >/dev/null || die "Azure CLI (az) not installed."
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run 'az login' first."
+
+# Select the shared subscription and bail if it isn't active, so we never tear
+# down resources in the wrong subscription.
+az account set --subscription "$SUBSCRIPTION_ID" 2>/dev/null \
+  || die "Could not select subscription $SUBSCRIPTION_ID. Run 'az login' then 'az account list -o table'."
+ACTIVE_SUB=$(az account show --query id -o tsv)
+[[ "$ACTIVE_SUB" == "$SUBSCRIPTION_ID" ]] \
+  || die "Active subscription is $ACTIVE_SUB but expected $SUBSCRIPTION_ID. Aborting."
 ACCOUNT_NAME=$(az account show --query name -o tsv)
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 
 if ! az group show --name "$RESOURCE_GROUP" >/dev/null 2>&1; then
   log "Resource group '$RESOURCE_GROUP' does not exist in subscription '$ACCOUNT_NAME'. Nothing to do."

--- a/infrastructure/create_three_vms.sh
+++ b/infrastructure/create_three_vms.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 # Run interactively the first time:   bash infrastructure/create_three_vms.sh
 # Safe to re-run: resource creation is idempotent; existing resources are reused.
 
+# Pin the Azure subscription so the deploy can never silently land in the wrong
+# one (e.g. a member's personal "Azure for Students" sub). This is the SHARED
+# team subscription that owns the static public IP — keeping every run here is
+# what makes the public IP stable across teardown/re-provision cycles.
+# Override only if the team's shared subscription changes: SUBSCRIPTION_ID=...
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-f0b6692d-2ce5-450d-a954-741c7cad136c}"
+
 RESOURCE_GROUP="${RESOURCE_GROUP:-rg-balladebaderne}"
 LOCATION="${LOCATION:-francecentral}"
 VNET_NAME="${VNET_NAME:-cookbook-vnet}"
@@ -96,8 +103,16 @@ if ! az account show >/dev/null 2>&1; then
   log "Not logged in to Azure — opening browser to sign in..."
   az login || die "Azure login failed."
 fi
+
+# Select the shared subscription and refuse to continue if it isn't active, so a
+# stale 'az' default (e.g. a personal sub) can't redirect the whole deployment.
+log "Selecting shared subscription $SUBSCRIPTION_ID..."
+az account set --subscription "$SUBSCRIPTION_ID" 2>/dev/null \
+  || die "Could not select subscription $SUBSCRIPTION_ID. Confirm you are a member: run 'az login' then 'az account list -o table'."
+ACTIVE_SUB=$(az account show --query id -o tsv)
+[[ "$ACTIVE_SUB" == "$SUBSCRIPTION_ID" ]] \
+  || die "Active subscription is $ACTIVE_SUB but expected $SUBSCRIPTION_ID. Aborting to avoid deploying to the wrong subscription."
 ACCOUNT_NAME=$(az account show --query name -o tsv)
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 SIGNED_IN_USER=$(az account show --query user.name -o tsv)
 
 log "Verifying GitHub login..."

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,28 @@
+# Alertmanager routing for the cookbook stack.
+#
+# Static and identical for dev/prod. Secrets are NEVER committed here:
+#   - Discord webhook URL is read from a file (webhook_url_file) — mounted at
+#     /etc/alertmanager/secrets/discord_url (bind from ./alertmanager/secrets/discord_url,
+#     which is gitignored). See discord_url.example for the format.
+#   - The GitHub token lives only as an env var on the github-receiver container.
+#
+# Routes every alert to two receivers:
+#   (a) Discord  → group is pinged immediately
+#   (b) webhook  → github-receiver opens/auto-closes a GitHub issue
+route:
+  receiver: cookbook
+  group_by: [alertname]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: cookbook
+    discord_configs:
+      - webhook_url_file: /etc/alertmanager/secrets/discord_url
+        send_resolved: true
+    webhook_configs:
+      # github-receiver: measurementlab/alertmanager-github-receiver, listens on
+      # :9393 with the receiver endpoint at /v1/receiver.
+      - url: http://github-receiver:9393/v1/receiver
+        send_resolved: true

--- a/monitoring/alertmanager/discord_url.example
+++ b/monitoring/alertmanager/discord_url.example
@@ -1,0 +1,1 @@
+https://discord.com/api/webhooks/REPLACE_WITH_CHANNEL_ID/REPLACE_WITH_TOKEN

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -111,18 +111,22 @@ services:
       - cookbook-network
 
   # Opens (and, with -enable-auto-close, closes) a GitHub issue per firing alert.
-  # GH_ISSUE_TOKEN is a fine-grained PAT (Issues: write on Balladebaderne/cookbook)
-  # supplied via the shell env in dev and via CI secrets in prod — never committed.
+  # Auth token is read from a gitignored secret file (same pattern as the Discord
+  # webhook): mounted at /etc/github-receiver/secrets/gh_token. The token is a
+  # fine-grained PAT (Issues: write on Balladebaderne/cookbook); in dev it can be
+  # the gh CLI token, in prod CI writes secrets.GH_ISSUE_TOKEN to the file. Never
+  # committed, never passed as a process arg.
   github-receiver:
-    image: measurementlab/alertmanager-github-receiver:latest
+    image: measurementlab/alertmanager-github-receiver:v0.11
     container_name: github-receiver
     restart: unless-stopped
     command:
       - "-org=Balladebaderne"
       - "-repo=cookbook"
       - "-enable-auto-close"
-    environment:
-      - GITHUB_AUTH_TOKEN=${GH_ISSUE_TOKEN:-}
+      - "-authtoken-file=/etc/github-receiver/secrets/gh_token"
+    volumes:
+      - ./github-receiver/secrets/gh_token:/etc/github-receiver/secrets/gh_token:ro
     expose:
       - "9393"
     networks:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./rules:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -88,6 +89,42 @@ services:
       - /:/rootfs:ro
     ports:
       - "127.0.0.1:9100:9100"
+    networks:
+      - cookbook-network
+
+  # Routes Prometheus alerts to Discord + the github-receiver.
+  # The Discord webhook URL is read from a gitignored bind file; the GitHub
+  # token never touches this container.
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    container_name: alertmanager
+    restart: unless-stopped
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./alertmanager/secrets/discord_url:/etc/alertmanager/secrets/discord_url:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    ports:
+      - "127.0.0.1:9093:9093"
+    networks:
+      - cookbook-network
+
+  # Opens (and, with -enable-auto-close, closes) a GitHub issue per firing alert.
+  # GH_ISSUE_TOKEN is a fine-grained PAT (Issues: write on Balladebaderne/cookbook)
+  # supplied via the shell env in dev and via CI secrets in prod — never committed.
+  github-receiver:
+    image: measurementlab/alertmanager-github-receiver:latest
+    container_name: github-receiver
+    restart: unless-stopped
+    command:
+      - "-org=Balladebaderne"
+      - "-repo=cookbook"
+      - "-enable-auto-close"
+    environment:
+      - GITHUB_AUTH_TOKEN=${GH_ISSUE_TOKEN:-}
+    expose:
+      - "9393"
     networks:
       - cookbook-network
 

--- a/monitoring/prometheus.prod.yml
+++ b/monitoring/prometheus.prod.yml
@@ -9,6 +9,14 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -2,6 +2,14 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/monitoring/rules/cookbook-alerts.yml
+++ b/monitoring/rules/cookbook-alerts.yml
@@ -1,0 +1,69 @@
+# Prometheus alert rules for the cookbook stack.
+#
+# These fire alerts that Alertmanager routes to Discord (group notification) and
+# the github-receiver (auto-opens/closes a GitHub issue). Only metrics we know
+# exist are used:
+#   - `up`                              (Prometheus target health)
+#   - `http_request_duration_seconds_*` (backend, prom-client — see backend/src/index.js)
+#   - `node_*`                          (node-exporter host metrics)
+#
+# Mounted into Prometheus at /etc/prometheus/rules/ (see docker-compose.yml).
+groups:
+  - name: cookbook
+    rules:
+      # Backend is unreachable. Aggregated with sum() so the always-down inactive
+      # blue/green color in prod (prometheus.prod.yml lists both 3001 and 3002)
+      # does NOT false-fire — we only alert when *no* backend target is up.
+      - alert: BackendDown
+        expr: sum(up{job="cookbook-backend"}) == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Backend is down"
+          description: "No cookbook-backend target has been scrapeable for 2m. The API is likely unreachable."
+
+      # A monitoring component itself went away (we lose visibility).
+      - alert: MonitoringTargetDown
+        expr: up{job=~"prometheus|cadvisor|node-exporter"} == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Monitoring target {{ $labels.job }} is down"
+          description: "Prometheus target {{ $labels.job }} ({{ $labels.instance }}) has been down for 5m."
+
+      # More than 5% of requests are returning 5xx.
+      - alert: HighErrorRate
+        expr: |
+          sum(rate(http_request_duration_seconds_count{status_code=~"5.."}[5m]))
+            / sum(rate(http_request_duration_seconds_count[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High 5xx error rate"
+          description: "More than 5% of backend requests have returned 5xx over the last 5m."
+
+      # Root filesystem is filling up.
+      - alert: DiskAlmostFull
+        expr: |
+          node_filesystem_avail_bytes{mountpoint="/"}
+            / node_filesystem_size_bytes{mountpoint="/"} < 0.15
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk almost full on {{ $labels.instance }}"
+          description: "Less than 15% free space on / for 10m."
+
+      # Host memory pressure.
+      - alert: HostMemoryPressure
+        expr: |
+          1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes > 0.9
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage on {{ $labels.instance }}"
+          description: "More than 90% of host memory in use for 10m."


### PR DESCRIPTION
## Summary

Promotes the latest `dev` work to `master` (auto-deploys to the VM). Three changes, all already merged to `dev`:

### 1. Phase 1 alerting (#132)
Prometheus alert rules → Alertmanager → Discord notification + auto-created/auto-closed GitHub issue.
- New alert rules (`monitoring/rules/cookbook-alerts.yml`): `BackendDown` (`sum(up)==0`), `MonitoringTargetDown`, 5xx error-rate, disk <15%, host-mem >90%.
- Wired `rule_files` + `alerting` into both `prometheus.yml` and `prometheus.prod.yml`.
- Added Alertmanager + github-receiver containers (pinned `v0.11`, auth working) and static Alertmanager config (Discord URL via `webhook_url_file`).
- **End-to-end tested locally**: Discord delivery + GitHub issue creation + auto-close on resolve all verified (see closed test issues #133–#135).

### 2. Pin shared Azure subscription
`create_three_vms.sh` and `azure-teardown.sh` now pin the shared team subscription so the static public IP `4.211.254.152` survives teardown/re-provision and can't land in a personal subscription.

### 3. Docs
`definition-of-done.md` updated for alerting (#132) and the static-IP guarantee.

## Issues
- Part of #132 — this delivers **Phase 1 only** (local, no secret/prod deps). **Not auto-closing**: Phase 2 (CI wiring to ship rules/config to the nginx VM + `DISCORD_WEBHOOK_URL`/`GH_ISSUE_TOKEN` secrets) still needs group sign-off.

## Notes
- No `.github/workflows/` changes. Infra script edits were already reviewed/merged on `dev`.
- No secrets committed; Discord URL stays in an untracked `*_url` file (`discord_url.example` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
