### PR TITLE
Hardening: image scan + Dockerfile lint, DB query metric, JWT prod hardening (#104 #105 #107 #110)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,13 +91,97 @@ jobs:
         working-directory: frontend
         run: npm test
 
+  # Course checklist 5.2: lint both Dockerfiles on every push + PR.
+  dockerfile-lint:
+    name: Lint Dockerfiles (hadolint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint backend Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: backend/Dockerfile
+
+      - name: Lint frontend Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: frontend/Dockerfile
+
+  # Course checklist 5.4 + 9.6: build both images and scan them with Trivy on
+  # every push + PR. Images are loaded locally only — never pushed or deployed
+  # here (build-and-push owns that, and gates on this job).
+  #
+  # Split policy (fixable CVEs only, --ignore-unfixed):
+  #   * HIGH/CRITICAL in our own application deps (library class) -> fail build
+  #   * HIGH/CRITICAL in the OS/base image (alpine)              -> report only
+  # We block on what we control (app dependencies) and only report base-image OS
+  # CVEs: those are upstream's to patch and churn constantly (alpine ships new
+  # ones weekly, criticals included), so we remediate them by bumping the pinned
+  # base image rather than blocking every PR on them.
+  image-scan:
+    name: Build & scan images (Trivy)
+    runs-on: ubuntu-latest
+    needs: dependency-audit
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: backend
+            context: .
+            dockerfile: ./backend/Dockerfile
+          - service: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.service }} image (load locally, no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: true
+          tags: cookbook-${{ matrix.service }}:scan
+
+      - name: Trivy ${{ matrix.service }} — block HIGH/CRITICAL in app dependencies
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: cookbook-${{ matrix.service }}:scan
+          format: table
+          scanners: vuln
+          ignore-unfixed: true
+          vuln-type: library
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Trivy ${{ matrix.service }} — report OS/base-image CVEs (no fail)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: cookbook-${{ matrix.service }}:scan
+          format: table
+          scanners: vuln
+          ignore-unfixed: true
+          vuln-type: os
+          severity: CRITICAL,HIGH
+          exit-code: '0'
+
   build-and-push:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
-    needs: dependency-audit
-    # On pull requests we only want the dependency-audit gate to report — not
-    # build/push images or deploy. Skipping this job also skips the deploy-*
-    # jobs that need it (they're additionally gated on master/dispatch).
+    needs: [dependency-audit, dockerfile-lint, image-scan]
+    # On pull requests we only want the gate jobs to report — not build/push
+    # images or deploy. Skipping this job also skips the deploy-* jobs that need
+    # it (they're additionally gated on master/dispatch).
     if: github.event_name != 'pull_request'
 
     permissions:
@@ -324,14 +408,17 @@ jobs:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: |
           OWNER_LC=$(echo "$OWNER_LC" | tr '[:upper:]' '[:lower:]')
           IMAGE_TAG="sha-${GITHUB_SHA}"
           POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 
-          for value in "$BACKEND_PRIVATE_IP" "$DATABASE_PRIVATE_IP" "$POSTGRES_DB" "$POSTGRES_USER" "$POSTGRES_PASSWORD"; do
+          # JWT_SECRET is required: the production backend refuses the committed
+          # default and would fail its health check, aborting the blue/green swap.
+          for value in "$BACKEND_PRIVATE_IP" "$DATABASE_PRIVATE_IP" "$POSTGRES_DB" "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$JWT_SECRET"; do
             if [ -z "$value" ]; then
-              echo "Missing required three-vms deploy secret" >&2
+              echo "Missing required three-vms deploy secret (one of BACKEND_PRIVATE_IP, DATABASE_PRIVATE_IP, POSTGRES_DB/USER/PASSWORD, JWT_SECRET)" >&2
               exit 1
             fi
           done
@@ -347,6 +434,7 @@ jobs:
             "POSTGRES_DB=$(quote "$POSTGRES_DB")"
             "POSTGRES_USER=$(quote "$POSTGRES_USER")"
             "POSTGRES_PASSWORD=$(quote "$POSTGRES_PASSWORD")"
+            "JWT_SECRET=$(quote "$JWT_SECRET")"
           )
 
           ssh -i ~/.ssh/id_rsa \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app/backend
 
@@ -6,11 +6,18 @@ WORKDIR /app/backend
 COPY backend/package.json backend/package-lock.json ./
 RUN npm ci --omit=dev
 
-# Copy the rest of the backend source
-COPY backend/ ./
+# Copy only the application source — not tests, coverage, or lint/test configs —
+# so the runtime image holds just the prod deps from `npm ci --omit=dev` plus src.
+COPY backend/src ./src
 
 # Copy the OpenAPI spec into the runtime image so `index.js` can find it
 COPY openapi.yaml /app/
+
+# Drop the bundled npm CLI from the runtime image. The app runs via `node` and
+# never needs a package manager in production; npm vendors its own (vulnerable)
+# copies of tar/glob/cross-spawn/minimatch, which are the only remaining image
+# CVEs once the app dependencies themselves are clean.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 EXPOSE 3000
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "bcrypt": "6.0.0",
+        "bcryptjs": "3.0.3",
         "jsonwebtoken": "9.0.3",
         "pg": "8.21.0",
         "prom-client": "15.1.3",
@@ -979,18 +979,13 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/binary-extensions": {
@@ -2309,26 +2304,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
     },
     "node_modules/nodemon": {
       "version": "3.1.14",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
   "author": "BalladeBaderne",
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "6.0.0",
+    "bcryptjs": "3.0.3",
     "jsonwebtoken": "9.0.3",
     "pg": "8.21.0",
     "prom-client": "15.1.3",

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -1,6 +1,29 @@
 import pg from "pg";
+import { dbQueryDuration } from "../metrics.js";
 
 const POSTGRES_REQUIRED_ENV = ["POSTGRES_HOST", "POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD"];
+
+// First SQL keyword (select/insert/update/delete/…) — the metric label, so DB
+// latency can be sliced by operation in Prometheus/Grafana without recording
+// the full (high-cardinality) query text.
+export function queryOperation(sql) {
+  const match = /^\s*([a-z]+)/i.exec(sql);
+  return match ? match[1].toLowerCase() : "other";
+}
+
+// Times a single query and records db_query_duration_seconds, labelled by
+// operation + success/error, regardless of whether the query throws.
+async function timedQuery(queryable, text, params, originalSql) {
+  const end = dbQueryDuration.startTimer({ operation: queryOperation(originalSql) });
+  try {
+    const result = await queryable.query(text, params);
+    end({ status: "success" });
+    return result;
+  } catch (err) {
+    end({ status: "error" });
+    throw err;
+  }
+}
 
 export function postgresConfig(env = process.env) {
   if (env.DATABASE_URL) {
@@ -93,16 +116,16 @@ class PostgresTransaction {
 export function postgresStatement(queryable, sql) {
   return {
     run: async (...params) => {
-      const result = await queryable.query(toPostgresSql(sqlWithReturningId(sql)), params);
+      const result = await timedQuery(queryable, toPostgresSql(sqlWithReturningId(sql)), params, sql);
       const id = result.rows[0]?.id;
       return { lastInsertRowid: id, rowCount: result.rowCount };
     },
     all: async (...params) => {
-      const result = await queryable.query(toPostgresSql(sql), params);
+      const result = await timedQuery(queryable, toPostgresSql(sql), params, sql);
       return result.rows || [];
     },
     get: async (...params) => {
-      const result = await queryable.query(toPostgresSql(sql), params);
+      const result = await timedQuery(queryable, toPostgresSql(sql), params, sql);
       return result.rows[0];
     },
   };

--- a/backend/src/db/index.test.js
+++ b/backend/src/db/index.test.js
@@ -3,9 +3,11 @@ import {
   postgresConfig,
   postgresStatement,
   PostgresDatabase,
+  queryOperation,
   sqlWithReturningId,
   toPostgresSql,
 } from "./index.js";
+import { register } from "../metrics.js";
 
 describe("db/index Postgres configuration", () => {
   it("uses DATABASE_URL as a connection string when present", () => {
@@ -86,6 +88,56 @@ describe("db/index Postgres SQL adapter", () => {
         params: [],
       },
     ]);
+  });
+
+  it("classifies the SQL operation for the db metric label", () => {
+    expect(queryOperation("SELECT * FROM recipes")).toBe("select");
+    expect(queryOperation("  insert into users (email) values (?)")).toBe("insert");
+    expect(queryOperation("UPDATE recipes SET title = ?")).toBe("update");
+    expect(queryOperation("DELETE FROM tags WHERE id = ?")).toBe("delete");
+    expect(queryOperation("")).toBe("other");
+  });
+
+  it("records db_query_duration_seconds for executed statements", async () => {
+    const queryable = {
+      async query() {
+        return { rows: [{ id: 1 }], rowCount: 1 };
+      },
+    };
+
+    await postgresStatement(queryable, "SELECT id FROM recipes WHERE id = ?").get(1);
+
+    const metrics = await register.getMetricsAsJSON();
+    const metric = metrics.find((m) => m.name === "db_query_duration_seconds");
+    expect(metric).toBeTruthy();
+
+    const count = metric.values.find(
+      (v) =>
+        v.metricName === "db_query_duration_seconds_count" &&
+        v.labels.operation === "select" &&
+        v.labels.status === "success"
+    );
+    expect(count?.value).toBeGreaterThanOrEqual(1);
+  });
+
+  it("records a failed db query with status=error and still rejects", async () => {
+    const queryable = {
+      async query() {
+        throw new Error("db down");
+      },
+    };
+
+    await expect(postgresStatement(queryable, "SELECT 1").all()).rejects.toThrow("db down");
+
+    const metrics = await register.getMetricsAsJSON();
+    const metric = metrics.find((m) => m.name === "db_query_duration_seconds");
+    const errorCount = metric.values.find(
+      (v) =>
+        v.metricName === "db_query_duration_seconds_count" &&
+        v.labels.operation === "select" &&
+        v.labels.status === "error"
+    );
+    expect(errorCount?.value).toBeGreaterThanOrEqual(1);
   });
 
   it("runs Postgres transactions on a single client and releases it", async () => {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,7 +3,8 @@ import YAML from "yamljs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { initDb } from "./db/schema.js";
-import client from "prom-client";
+import { register, httpRequestDuration } from "./metrics.js";
+import { assertAuthConfig } from "./services/users.js";
 
 import apiRoutes from "./routes/api.js";
 import recipeRoutes from "./routes/recipes.js";
@@ -16,18 +17,6 @@ import { errorHandler, notFound } from "./middleware/error.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PORT = process.env.PORT || 3000;
-
-// ── Prometheus metrics ────────────────────────────────────────────────────────
-const register = new client.Registry();
-client.collectDefaultMetrics({ register });
-
-const httpRequestDuration = new client.Histogram({
-  name: "http_request_duration_seconds",
-  help: "Duration of HTTP requests in seconds",
-  labelNames: ["method", "route", "status_code"],
-  registers: [register],
-});
-// ─────────────────────────────────────────────────────────────────────────────
 
 // Load OpenAPI spec
 const swaggerDocument = YAML.load(path.join(__dirname, "..", "..", "openapi.yaml"));
@@ -77,6 +66,7 @@ export function createApp() {
 }
 
 export async function createServer() {
+  assertAuthConfig();
   await initDb();
   return http.createServer(createApp());
 }

--- a/backend/src/metrics.js
+++ b/backend/src/metrics.js
@@ -1,0 +1,22 @@
+import client from "prom-client";
+
+// One shared registry for the whole backend so every layer (HTTP handler, data
+// layer) reports into the same `/metrics` output. Defining the metrics here —
+// rather than inline in index.js — lets the db layer record query timings
+// without index.js and db/index.js importing each other.
+export const register = new client.Registry();
+client.collectDefaultMetrics({ register });
+
+export const httpRequestDuration = new client.Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status_code"],
+  registers: [register],
+});
+
+export const dbQueryDuration = new client.Histogram({
+  name: "db_query_duration_seconds",
+  help: "Duration of database queries in seconds",
+  labelNames: ["operation", "status"],
+  registers: [register],
+});

--- a/backend/src/services/users.js
+++ b/backend/src/services/users.js
@@ -1,4 +1,4 @@
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { db } from "../db/index.js";
 import { HttpError } from "../middleware/error.js";
@@ -12,7 +12,25 @@ function normalizeEmail(email) {
 }
 
 function tokenSecret() {
-  return process.env.JWT_SECRET || DEFAULT_JWT_SECRET;
+  const secret = process.env.JWT_SECRET;
+  if (secret) return secret;
+  // In production we must never sign/verify JWTs with a value committed to the
+  // repo — anyone reading the source could forge a valid token. Fail loudly
+  // instead of silently falling back to DEFAULT_JWT_SECRET. The fallback stays
+  // for local dev/test convenience (NODE_ENV !== "production").
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "JWT_SECRET must be set in production; refusing to fall back to the committed default secret."
+    );
+  }
+  return DEFAULT_JWT_SECRET;
+}
+
+// Surfaces a missing production JWT_SECRET at boot (see createServer) so a
+// misconfigured deploy fails its health check immediately, instead of booting
+// fine and then 500-ing on the first auth request.
+export function assertAuthConfig() {
+  tokenSecret();
 }
 
 function publicUser(row) {

--- a/deploy/blue-green/backend-blue-green.yml
+++ b/deploy/blue-green/backend-blue-green.yml
@@ -8,6 +8,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: 3000
+      JWT_SECRET: ${JWT_SECRET:-}
       DATABASE_URL: ${DATABASE_URL:-}
       POSTGRES_HOST: ${POSTGRES_HOST:-}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}
@@ -30,6 +31,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: 3000
+      JWT_SECRET: ${JWT_SECRET:-}
       DATABASE_URL: ${DATABASE_URL:-}
       POSTGRES_HOST: ${POSTGRES_HOST:-}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}

--- a/deploy/blue-green/deploy-blue-green.sh
+++ b/deploy/blue-green/deploy-blue-green.sh
@@ -88,6 +88,10 @@ BLUE_BACKEND_HOST="$BACKEND_PRIVATE_IP:3001"
 GREEN_BACKEND_HOST="$BACKEND_PRIVATE_IP:3002"
 
 export GITHUB_OWNER BACKEND_IMAGE_TAG
+# JWT_SECRET is passed in via the CI deploy env (never written to active-color.env,
+# which is world-readable and synced between VMs). The backend fails to boot in
+# production if it is empty — see backend/src/services/users.js.
+export JWT_SECRET="${JWT_SECRET:-}"
 export DATABASE_URL="${DATABASE_URL:-}"
 export POSTGRES_HOST="${POSTGRES_HOST:-}"
 export POSTGRES_PORT="${POSTGRES_PORT:-5432}"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
-RUN npm run lint
-RUN npm run build
+RUN npm run lint && npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## In plain terms — what this fixes in our system

Four backlog items, all aimed at making our containers and auth safer and our monitoring fuller. Nothing changes how the app *behaves* for users; it changes how it's built, scanned, secured, and observed.

| # | Before | After |
|---|--------|-------|
| **#110** | Production signed/verified JWTs with a **secret committed to the repo** — anyone reading the source could forge a login token. | The backend **refuses to start in production without a real `JWT_SECRET`** (no silent fallback). Wired through the deploy job, compose file and deploy script. |
| **#104** | We had **no image vulnerability scanning**, PRs never built/scanned images, and the base image (`node:18-alpine`, now EOL) carried CVEs. | Every push/PR **builds both images and scans them with Trivy**. Base bumped to `node:20-alpine`, `bcrypt`→`bcryptjs` (drops a native build + its vulnerable deps), and the unused `npm` CLI is stripped from the runtime image. Backend image is now **0 findings**. |
| **#105** | Dockerfiles were never linted. | **hadolint** runs on every push/PR; fixed the frontend warning. |
| **#107** | We measured HTTP latency but **not database latency**. | New `db_query_duration_seconds` Prometheus histogram times every DB query (by operation + success/error). |

### A bit more detail

**#104 — image scanning + hardening.** The only real source of image CVEs turned out to be tooling bundled in the base image (npm's own vendored `tar`/`glob`/`cross-spawn`), not our code. So we bump the base, remove the native `bcrypt` build chain (swap to pure-JS `bcryptjs`), and strip `npm` from the final image. The Trivy gate uses a **split policy**: it **fails the build on HIGH/CRITICAL in our own dependencies**, and **only reports** base-image OS CVEs (alpine ships new ones constantly — those are remediated by bumping the base, not by blocking every PR). PR builds scan **without** pushing or deploying.

**#110 — JWT secret.** `tokenSecret()` throws in `NODE_ENV=production` if `JWT_SECRET` is unset; the check runs at boot, so a misconfigured deploy fails its health check instead of running insecurely. Local dev/test keep the convenience fallback.

## How it was verified (locally, in Docker)

- Backend tests **29/29**, frontend **7/7**, `security-check.sh` **PASS**
- Auth proven end-to-end on `bcryptjs`: register (hash), login (compare), wrong password → 401
- `/metrics` exposes `db_query_duration_seconds` live (labelled `operation`/`status`)
- Prod fail-fast proven: **no `JWT_SECRET` → backend refuses to boot**; with secret → boots + `/health` 200
- Trivy gate green (backend clean; frontend reports only nginx-base CVEs); hadolint clean

## ⚠️ Before this can go to production (not local-testable)

1. **Create a `JWT_SECRET` repo secret** (`openssl rand -hex 32`) **before** any master deploy — otherwise the backend deploy **fails by design** (this is the fail-fast working as intended).
2. Setting the secret + deploying **logs all current users out** (old tokens become invalid) — coordinate at release.
3. The CI jobs (trivy-action / hadolint-action / buildx) were validated via the tools locally but **not yet on the GitHub runner**, and the real blue/green deploy hasn't been exercised.

## Notes

Addresses **#104, #105, #107, #110**. Touches the protected `.github/workflows/ci-cd.yml` (the CI scan/lint jobs + JWT wiring) — flagged for review. Not closing the issues here: please review and confirm the pre-prod checklist before we adopt this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)