### PR TITLE
fix(monitoring): raise HostMemoryPressure threshold 90%->95% to stop alert flapping

### DIFF
--- a/monitoring/rules/cookbook-alerts.yml
+++ b/monitoring/rules/cookbook-alerts.yml
@@ -58,12 +58,16 @@ groups:
           description: "Less than 15% free space on / for 10m."
 
       # Host memory pressure.
+      # Threshold is 95% (not 90%): the VM baseline averages ~87% RAM and pokes
+      # above 90% roughly a third of the time, which made the alert flap and spam
+      # Discord. Over a ~52h sample it crossed 95% exactly once (for ~1m), so 95%
+      # with for:10m removes the noise while still catching a genuine runaway.
       - alert: HostMemoryPressure
         expr: |
-          1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes > 0.9
+          1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes > 0.95
         for: 10m
         labels:
           severity: warning
         annotations:
           summary: "High memory usage on {{ $labels.instance }}"
-          description: "More than 90% of host memory in use for 10m."
+          description: "More than 95% of host memory in use for 10m."


### PR DESCRIPTION
## What
Raises the `HostMemoryPressure` alert threshold from **90% → 95%** in [`monitoring/rules/cookbook-alerts.yml`](monitoring/rules/cookbook-alerts.yml). `for: 10m`, `severity: warning` and the Discord/GitHub resolved-pings are unchanged.

## Why
The Frida (Alertmanager→Discord) bot fired ~20 alerts in 20h — the alert was **flapping** around the threshold. Pulled the actual numbers from Prometheus on the nginx VM (~52h of retained history):

| Metric | Value |
|---|---|
| Avg RAM | 87.3% |
| Peak | 96.6% |
| Time above 90% | ~34% of the time |
| Crossings of 90% | ~123 |
| Crossings of **95%** | **1** (for ~1 min) |

The VM baseline sits in the high-80s and pokes above 90% a third of the time, so 90% is unusable as a warning line. It crossed 95% exactly once (1 min) — which would not survive `for: 10m`. So 95% removes the noise while still catching a genuine sustained runaway toward OOM.

## Notes
- This PR also carries a back-merge of `master` into `dev` (intro-text from #138 that had not flowed back), so the net diff here is **only** the alert file and master's content is not reverted.
- Takes effect on the next deploy; Prometheus reloads rules on deploy.

## Definition of Done
- [x] Security gate (`scripts/security-check.sh`) passes
- [x] Net diff limited to the intended change

🤖 Generated with [Claude Code](https://claude.com/claude-code)